### PR TITLE
fix: don't fail if JSON.parse fails on docker output for pg-test/mysql-test

### DIFF
--- a/packages/mysql-test/package.json
+++ b/packages/mysql-test/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@databases/mysql-test",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
     "@databases/mysql-config": "^0.0.0",
-    "@databases/with-container": "^0.0.0",
+    "@databases/with-container": "^0.0.1",
     "mysql2": "^1.6.4",
     "yargs": "^12.0.5"
   },

--- a/packages/pg-test/package.json
+++ b/packages/pg-test/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@databases/pg-test",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
     "@databases/pg-config": "^0.0.0",
-    "@databases/with-container": "^0.0.0"
+    "@databases/with-container": "^0.0.1"
   },
   "scripts": {},
   "repository": "https://github.com/ForbesLindesay/atdatabases/tree/master/packages/pg-test",

--- a/packages/with-container/package.json
+++ b/packages/with-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databases/with-container",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/with-container/src/index.ts
+++ b/packages/with-container/src/index.ts
@@ -44,7 +44,15 @@ export async function imageExists(
     .toString('utf8')
     .trim()
     .split('\n')
-    .map(str => JSON.parse(str));
+    .map(str => {
+      try {
+        return JSON.parse(str);
+      } catch (ex) {
+        console.warn('Unable to parse: ' + str);
+        return null;
+      }
+    })
+    .filter(n => n != null);
   const [Repository, Tag] = options.image.split(':');
   return existingImages.some(
     i => i.Repository === Repository && (!Tag || i.Tag === Tag),


### PR DESCRIPTION
This seems to cause problems when trying to use docker on Circle CI. It seems best to just be tolerant of some lines not being valid JSON.