### PR TITLE
fix: remove stub types for ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@babel/code-frame": "^7.0.0",
     "@babel/core": "^7.2.2",
     "@moped/babel-preset": "^0.0.8",
-    "@types/ajv": "^1.0.0",
     "@types/cosmiconfig": "^5.0.3",
     "@types/cross-spawn": "^6.0.0",
     "@types/jest": "^23.3.10",

--- a/packages/mysql-config/package.json
+++ b/packages/mysql-config/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@databases/mysql-config",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@types/ajv": "^1.0.0",
     "@types/cosmiconfig": "^5.0.3",
     "ajv": "^6.7.0",
     "cosmiconfig": "^5.0.7"

--- a/packages/mysql-test/README.md
+++ b/packages/mysql-test/README.md
@@ -1,0 +1,3 @@
+# @databases/mysql-test
+
+For documentation, see https://www.atdatabases.com/docs/mysql-test

--- a/packages/mysql-test/package.json
+++ b/packages/mysql-test/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databases/mysql-test",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/mysql-config": "^0.0.0",
+    "@databases/mysql-config": "^1.0.0",
     "@databases/with-container": "^0.0.1",
     "mysql2": "^1.6.4",
     "yargs": "^12.0.5"
@@ -16,5 +16,6 @@
   "license": "GPL-3.0",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "homepage": "https://www.atdatabases.com/docs/mysql-test"
 }

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@databases/mysql",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
-    "@databases/mysql-config": "^0.0.0",
+    "@databases/mysql-config": "^1.0.0",
     "@databases/sql": "^1.0.1",
     "@types/mysql": "^2.15.5",
     "mysql2": "^1.6.4"

--- a/packages/pg-config/package.json
+++ b/packages/pg-config/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@databases/pg-config",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@types/ajv": "^1.0.0",
     "@types/cosmiconfig": "^5.0.3",
     "ajv": "^6.7.0",
     "cosmiconfig": "^5.0.7"

--- a/packages/pg-test/README.md
+++ b/packages/pg-test/README.md
@@ -1,0 +1,3 @@
+# @databases/pg-test
+
+For documentation, see https://www.atdatabases.com/docs/pg-test

--- a/packages/pg-test/package.json
+++ b/packages/pg-test/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databases/pg-test",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/pg-config": "^0.0.0",
+    "@databases/pg-config": "^1.0.0",
     "@databases/with-container": "^0.0.1"
   },
   "scripts": {},
@@ -17,5 +17,6 @@
   "devDependencies": {
     "@types/node": "^10.12.17"
   },
-  "bugs": "https://github.com/ForbesLindesay/atdatabases/issues"
+  "bugs": "https://github.com/ForbesLindesay/atdatabases/issues",
+  "homepage": "https://www.atdatabases.com/docs/pg-test"
 }

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@databases/pg",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
-    "@databases/pg-config": "^0.0.0",
+    "@databases/pg-config": "^1.0.0",
     "@databases/pg-data-type-id": "^0.0.0",
     "@databases/pg-errors": "^0.0.0",
     "@databases/sql": "^1.0.1",

--- a/packages/sqlite/README.md
+++ b/packages/sqlite/README.md
@@ -1,0 +1,3 @@
+# @databases/sqlite
+
+For documentation, see https://www.atdatabases.com/docs/sqlite

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -15,5 +15,6 @@
   "license": "GPL-3.0",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "homepage": "https://www.atdatabases.com/docs/sqlite"
 }


### PR DESCRIPTION
This was producing a deprecation warning on install.