### PR TITLE
feat: `queryStream` returns an AsyncIterableIterator

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -38,6 +38,26 @@ The `ConnectionPool` inherits from `Connection`, so you call `ConnectionPool.que
 
 Run an SQL Query and get a promise for an array of results.
 
+### ``` Conneciton.queryStream(SQLQuery): AsyncIterable<any> ```
+
+Run an SQL Query and get an async iterable of the results. e.g.
+
+```js
+for await (const record of db.queryStream(sql`SELECT * FROM massive_table`)) {
+  console.log(result);
+}
+```
+
+### ``` Conneciton.queryNodeStream(SQLQuery): ReadableStream ```
+
+Run an SQL Query and get a node.js readable stream of the results. e.g.
+
+```js
+const Stringifier = require('newline-json').Stringifier;
+
+db.queryNodeStream(sql`SELECT * FROM massive_table`).pipe(new Stringifier()).pipe(process.stdout);
+```
+
 ### ``` Connection.task(fn): Promise<T> ```
 
 Executes a callback function with automatically managed connection.

--- a/docs/pg.md
+++ b/docs/pg.md
@@ -41,6 +41,27 @@ The `ConnectionPool` inherits from `Connection`, so you call `ConnectionPool.que
 
 Run an SQL Query and get a promise for an array of results.
 
+
+### ``` Conneciton.queryStream(SQLQuery): AsyncIterable<any> ```
+
+Run an SQL Query and get an async iterable of the results. e.g.
+
+```js
+for await (const record of db.queryStream(sql`SELECT * FROM massive_table`)) {
+  console.log(result);
+}
+```
+
+### ``` Conneciton.queryNodeStream(SQLQuery): ReadableStream ```
+
+Run an SQL Query and get a node.js readable stream of the results. e.g.
+
+```js
+const Stringifier = require('newline-json').Stringifier;
+
+db.queryNodeStream(sql`SELECT * FROM massive_table`).pipe(new Stringifier()).pipe(process.stdout);
+```
+
 ### ``` Connection.task(fn, options?): Promise<T> ```
 
 Executes a callback function with automatically managed connection.

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -50,6 +50,16 @@ The `Database` inherits from `DatabaseTransaction`, so you call `Database.query`
 
 Run an SQL Query and get a promise for an array of results.
 
+### ``` Conneciton.queryStream(SQLQuery): AsyncIterable<any> ```
+
+Run an SQL Query and get an async iterable of the results. e.g.
+
+```js
+for await (const record of db.queryStream(sql`SELECT * FROM massive_table`)) {
+  console.log(result);
+}
+```
+
 ### ``` Connection.tx(fn): Promise<T> ```
 
 Executes a callback function as a transaction, with automatically managed connection.

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "prettier": "^1.15.3",
     "rimraf": "^2.6.2",
     "sqlite3": "^4.0.6",
+    "then-queue": "^1.3.0",
     "ts-jest": "^23.10.5",
     "tslint": "^5.12.0",
     "typescript": "^3.2.2",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@databases/mysql",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "@databases/mysql-config": "^1.0.1",
+    "@databases/push-to-async-iterable": "^1.0.0",
     "@databases/sql": "^1.0.3",
     "@types/mysql": "^2.15.5",
     "mysql2": "^1.6.4"

--- a/packages/mysql/src/__tests__/stream.test.ts
+++ b/packages/mysql/src/__tests__/stream.test.ts
@@ -1,0 +1,50 @@
+import connect, {sql} from '../';
+
+jest.setTimeout(30000);
+
+const db = connect();
+
+const allValues: number[] = [];
+beforeAll(async () => {
+  await db.query(
+    sql`CREATE TABLE streaming_test_values (id BIGINT NOT NULL PRIMARY KEY);`,
+  );
+  for (let batch = 0; batch < 10; batch++) {
+    const batchValues = [];
+    for (let i = 0; i < 1000; i++) {
+      const value = batch * 1000 + i;
+      batchValues.push(value);
+      allValues.push(value);
+    }
+    await db.query(sql`
+      INSERT INTO streaming_test_values (id)
+      VALUES ${sql.join(batchValues.map(v => sql`(${v})`), ',')};
+    `);
+  }
+});
+
+test('node streaming', async () => {
+  const results = await new Promise<any[]>((resolve, reject) => {
+    const results: number[] = [];
+    db.queryNodeStream(sql`SELECT * FROM streaming_test_values`, {
+      highWaterMark: 1,
+    })
+      .on('data', data => results.push(data.id))
+      .on('error', reject)
+      .on('end', () => resolve(results));
+  });
+  expect(results).toEqual(allValues);
+});
+
+test('await streaming', async () => {
+  const results: number[] = [];
+  for await (const {id} of db.queryStream(
+    sql`SELECT * FROM streaming_test_values`,
+    {
+      highWaterMark: 1,
+    },
+  )) {
+    results.push(id);
+  }
+  expect(results).toEqual(allValues);
+});

--- a/packages/mysql/src/raw.ts
+++ b/packages/mysql/src/raw.ts
@@ -1,13 +1,61 @@
+import {ReadableOptions} from 'stream';
+
 const mysql: {
   createPool: (opts: any) => Pool;
 } = require('mysql2/promise');
 
 // Create the connection pool. The pool-specific settings are the defaults
 
+// this.on('result', row => {
+//   if (!stream.push(row)) {
+//     this._connection.pause();
+//   }
+//   stream.emit('result', row); // replicate old emitter
+// });
+// this.on('error', err => {
+//   stream.emit('error', err); // Pass on any errors
+// });
+// this.on('end', () => {
+//   stream.push(null); // pushing null, indicating EOF
+//   stream.emit('close'); // notify readers that query has completed
+// });
+// this.on('fields', fields => {
+//   stream.emit('fields', fields); // replicate old emitter
+// });
+export interface ColumnDefinition {
+  characterSet: number;
+  encoding: string;
+  name: string;
+  columnLength: number;
+  columnType: number;
+  flags: number;
+  decimals: number;
+}
+export interface QueryCmd {
+  on(event: 'result', fn: (row: any) => void): this;
+  on(event: 'error', fn: (err: any) => void): this;
+  on(event: 'end', fn: () => void): this;
+  on(
+    event: 'fields',
+    fn: (fields: undefined | ColumnDefinition[]) => void,
+  ): this;
+
+  // Also emits the "fields" event as above
+  stream(options?: ReadableOptions): NodeJS.ReadableStream;
+}
+export interface CoreConnection {
+  query(sql: string, args: any[]): QueryCmd;
+  pause(): void;
+  resume(): void;
+}
 export interface PoolConnection {
+  readonly connection: CoreConnection;
   release(): void;
   destroy(): void;
-  query(sql: string, args: any[]): Promise<[unknown[], unknown[]]>;
+  query(
+    sql: string,
+    args: any[],
+  ): Promise<[unknown[], undefined | ColumnDefinition[]]>;
   execute(sql: string, args: any[]): Promise<unknown>;
   beginTransaction(): Promise<void>;
   commit(): Promise<void>;
@@ -16,7 +64,10 @@ export interface PoolConnection {
 }
 export interface Pool {
   getConnection(): Promise<PoolConnection>;
-  query(sql: string, args: any[]): Promise<[unknown[], unknown[]]>;
+  query(
+    sql: string,
+    args: any[],
+  ): Promise<[unknown[], undefined | ColumnDefinition[]]>;
   execute(sql: string, args: any[]): Promise<unknown>;
   end(): Promise<void>;
 }

--- a/packages/pg-create/package.json
+++ b/packages/pg-create/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/pg": "^1.0.0",
+    "@databases/pg": "^1.2.0",
     "@types/rimraf": "^2.0.2",
     "chalk": "^2.4.1",
     "cross-spawn": "^6.0.5",

--- a/packages/pg-migrations/package.json
+++ b/packages/pg-migrations/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/pg": "^1.1.1",
+    "@databases/pg": "^1.2.0",
     "chalk": "^2.4.1",
     "prettier": "^1.15.3"
   },

--- a/packages/pg-schema/package.json
+++ b/packages/pg-schema/package.json
@@ -6,7 +6,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/pg": "^1.1.1"
+    "@databases/pg": "^1.2.0"
   },
   "devDependencies": {
     "@types/node": "^10.12.17",

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -9,6 +9,7 @@
     "@databases/pg-config": "^1.0.1",
     "@databases/pg-data-type-id": "^0.0.1",
     "@databases/pg-errors": "^0.0.1",
+    "@databases/push-to-async-iterable": "^1.0.0",
     "@databases/sql": "^1.0.3",
     "@types/pg-query-stream": "^1.0.2",
     "pg-promise": "^8.6.0",

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databases/pg",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/push-to-async-iterable/package.json
+++ b/packages/push-to-async-iterable/package.json
@@ -1,23 +1,19 @@
 {
-  "name": "@databases/sqlite",
-  "version": "1.1.0",
+  "name": "@databases/push-to-async-iterable",
+  "version": "1.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/sql": "^1.0.3",
-    "@types/sqlite3": "^3.1.5",
-    "sqlite3": "^4.0.6",
     "then-queue": "^1.3.0"
   },
   "scripts": {},
-  "repository": "https://github.com/ForbesLindesay/atdatabases/tree/master/packages/sqlite",
+  "repository": "https://github.com/ForbesLindesay/atdatabases/tree/master/packages/push-to-async-iterable",
   "bugs": "https://github.com/ForbesLindesay/atdatabases/issues",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://www.atdatabases.org/docs/sqlite",
   "files": [
     "lib/"
   ]

--- a/packages/push-to-async-iterable/src/__tests__/index.test.ts
+++ b/packages/push-to-async-iterable/src/__tests__/index.test.ts
@@ -1,0 +1,101 @@
+import pushToAsyncIterable from '../';
+
+test('pushToAsyncIterable', async () => {
+  const pause = jest.fn();
+  const resume = jest.fn();
+  let onData!: (data: number) => void;
+  let onError!: (err: any) => void;
+  let onEnd!: () => void;
+  const result = pushToAsyncIterable<number>({
+    onData(fn) {
+      onData = fn;
+    },
+    onError(fn) {
+      onError = fn;
+    },
+    onEnd(fn) {
+      onEnd = fn;
+    },
+    pause,
+    resume,
+    highWaterMark: 2,
+  });
+  onData(1);
+  expect(pause).not.toBeCalled();
+  expect(resume).not.toBeCalled();
+
+  expect(await result.next()).toEqual({done: false, value: 1});
+  expect(pause).not.toBeCalled();
+  expect(resume).not.toBeCalled();
+
+  onData(2);
+  expect(pause).not.toBeCalled();
+  expect(resume).not.toBeCalled();
+
+  onData(3);
+  expect(pause).toBeCalledTimes(1);
+  expect(resume).not.toBeCalled();
+
+  onData(4);
+  expect(pause).toBeCalledTimes(1);
+  expect(resume).not.toBeCalled();
+
+  expect(await result.next()).toEqual({done: false, value: 2});
+  expect(pause).toBeCalledTimes(1);
+  expect(resume).not.toBeCalled();
+
+  expect(await result.next()).toEqual({done: false, value: 3});
+  expect(pause).toBeCalledTimes(1);
+  expect(resume).toBeCalledTimes(1);
+
+  expect(await result.next()).toEqual({done: false, value: 4});
+  expect(pause).toBeCalledTimes(1);
+  expect(resume).toBeCalledTimes(1);
+
+  onEnd();
+  expect(pause).toBeCalledTimes(1);
+  expect(resume).toBeCalledTimes(1);
+
+  expect(await result.next()).toEqual({done: true});
+  expect(pause).toBeCalledTimes(1);
+  expect(resume).toBeCalledTimes(1);
+
+  expect(typeof onError).toBe('function');
+});
+
+test('pushToAsyncIterable Error', async () => {
+  const pause = jest.fn();
+  const resume = jest.fn();
+  let onData!: (data: number) => void;
+  let onError!: (err: any) => void;
+  let onEnd!: () => void;
+  const result = pushToAsyncIterable<number>({
+    onData(fn) {
+      onData = fn;
+    },
+    onError(fn) {
+      onError = fn;
+    },
+    onEnd(fn) {
+      onEnd = fn;
+    },
+    pause,
+    resume,
+    highWaterMark: 2,
+  });
+  onData(1);
+  expect(pause).not.toBeCalled();
+  expect(resume).not.toBeCalled();
+
+  expect(await result.next()).toEqual({done: false, value: 1});
+  expect(pause).not.toBeCalled();
+  expect(resume).not.toBeCalled();
+
+  const TEST_ERROR = {};
+  onError(TEST_ERROR);
+  await expect(result.next()).rejects.toBe(TEST_ERROR);
+  expect(pause).not.toBeCalled();
+  expect(resume).not.toBeCalled();
+
+  expect(typeof onEnd).toBe('function');
+});

--- a/packages/push-to-async-iterable/src/index.ts
+++ b/packages/push-to-async-iterable/src/index.ts
@@ -1,0 +1,75 @@
+const Queue = require('then-queue');
+interface Queue<T> {
+  push(item: T): void;
+  pop(): Promise<T>;
+  /**
+   * Amount of items in the queue
+   * This can be negative if pop has been called more times than push.
+   */
+  length: number;
+}
+interface PushStream<T> {
+  onData(fn: (value: T) => void): void;
+  onError(fn: (err: any) => void): void;
+  onEnd(fn: () => void): void;
+  pause(): void;
+  resume(): void;
+  highWaterMark: number;
+}
+export default function pushToAsyncIterable<T>(stream: PushStream<T>) {
+  const queue: Queue<
+    {done: false; value: T} | {done: true; err: any}
+  > = new Queue();
+  let paused = false;
+  let ended = false;
+  stream.onData(value => {
+    if (!ended) {
+      queue.push({done: false, value});
+      if (!paused && queue.length >= stream.highWaterMark) {
+        paused = true;
+        stream.pause();
+      }
+    }
+  });
+  stream.onError(err => {
+    if (!ended) {
+      ended = true;
+      queue.push({done: true, err});
+      if (paused) {
+        paused = false;
+        stream.resume();
+      }
+    }
+  });
+  stream.onEnd(() => {
+    if (!ended) {
+      ended = true;
+      queue.push({done: true, err: undefined});
+      if (paused) {
+        paused = false;
+        stream.resume();
+      }
+    }
+  });
+  return queueConsumer(queue, () => {
+    if (paused && queue.length < stream.highWaterMark) {
+      paused = false;
+      stream.resume();
+    }
+  });
+}
+async function* queueConsumer<T>(
+  queue: Queue<{done: false; value: T} | {done: true; err: any}>,
+  onPop: () => void,
+) {
+  let value = await queue.pop();
+  while (!value.done) {
+    yield value.value;
+    const next = queue.pop();
+    onPop();
+    value = await next;
+  }
+  if (value.err) {
+    throw value.err;
+  }
+}

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databases/sqlite",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/sqlite/src/__tests__/stream.test.ts
+++ b/packages/sqlite/src/__tests__/stream.test.ts
@@ -22,7 +22,7 @@ test('streaming', async () => {
     `);
   }
   const results = [];
-  for await (const row of db.stream(sql`SELECT * FROM stream_values`)) {
+  for await (const row of db.queryStream(sql`SELECT * FROM stream_values`)) {
     results.push(row.id);
   }
   expect(results).toEqual(allValues);

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -40,7 +40,13 @@ export class DatabaseTransaction {
     return runQuery(query, this._database, async fn => fn());
   }
 
+  /**
+   * @deprecated use queryStream
+   */
   stream(query: SQLQuery): AsyncIterableIterator<any> {
+    return this.queryStream(query);
+  }
+  queryStream(query: SQLQuery): AsyncIterableIterator<any> {
     return runQueryStream(query, this._database, async fn => fn());
   }
 }
@@ -64,7 +70,13 @@ export class DatabaseConnection {
     );
   }
 
+  /**
+   * @deprecated use queryStream
+   */
   stream(query: SQLQuery): AsyncIterableIterator<any> {
+    return this.queryStream(query);
+  }
+  queryStream(query: SQLQuery): AsyncIterableIterator<any> {
     return runQueryStream(query, this._database, async fn =>
       this._mutex.readLock(fn),
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,6 +4761,13 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+then-queue@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/then-queue/-/then-queue-1.3.0.tgz#19f63c2a93335ba54ea942f7eca3d6b8899015fb"
+  integrity sha1-GfY8KpMzW6VOqUL37KPWuImQFfs=
+  dependencies:
+    promise "^6.0.0"
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"


### PR DESCRIPTION
This adds a proper documented method for querying a database and streaming the results out. This can be used for querying very large tables when you want to fetch all results and process them as a stream.

[closes #38]