### PR TITLE
feat: add "sql.file" method for reading in SQL from files

### DIFF
--- a/docs/sql.md
+++ b/docs/sql.md
@@ -90,6 +90,17 @@ sql`WHERE (${sql.join(arrayOfSqlConditions, ') AND (')})`;
 
 > N.B. the delimiter should always be a string literal, never allow user input to be passed as the delimiter. If you allow user specified delimiters, it will lead to an SQL Injection Vulnerability.
 
+### ``` sql.file(filename) ```
+
+This reads a file containing an SQL query in utf8 text, and returns it as an SQLQuery. It's generally most useful for large blocks of SQL, like database migrations.
+
+```ts
+const migration = sql.file(`${__dirname}/my-migration.sql`);
+db.query(migration);
+```
+
+> N.B. if you allow users to write to the files that you later read in as queries via this method, your code will be vulnerable to SQL Injeciton. Only read in trusted files created by your own team of developers.
+
 ### ``` sql.__dangerous__rawValue(str) ```
 
 This is an escape hatch to allow you to take a string from a source you trust and treat it as an SQL query. There is almost always a better way.

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -8,7 +8,7 @@
     "@babel/code-frame": "^7.0.0",
     "@databases/mysql-config": "^1.0.1",
     "@databases/push-to-async-iterable": "^1.0.0",
-    "@databases/sql": "^1.0.3",
+    "@databases/sql": "^1.1.0",
     "@types/mysql": "^2.15.5",
     "mysql2": "^1.6.4"
   },

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -10,7 +10,7 @@
     "@databases/pg-data-type-id": "^0.0.1",
     "@databases/pg-errors": "^0.0.1",
     "@databases/push-to-async-iterable": "^1.0.0",
-    "@databases/sql": "^1.0.3",
+    "@databases/sql": "^1.1.0",
     "@types/pg-query-stream": "^1.0.2",
     "pg-promise": "^8.6.0",
     "pg-query-stream": "1.1.2"

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databases/sql",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/sql/src/SQLQuery.ts
+++ b/packages/sql/src/SQLQuery.ts
@@ -1,4 +1,5 @@
 import minify = require('pg-minify');
+import {readFileSync} from 'fs';
 
 /**
  * A Postgres query which may be fed directly into the `pg` module for
@@ -130,6 +131,15 @@ export default class SQLQuery implements PGQuery {
   }
 
   /**
+   * Creates a new query with the contents of a utf8 file
+   */
+  public static file(filename: string): SQLQuery {
+    return new SQLQuery([
+      {type: SQLItemType.RAW, text: readFileSync(filename, 'utf8')},
+    ]);
+  }
+
+  /**
    * Creates a new query with the raw text.
    */
   public static raw(text: string): SQLQuery {
@@ -249,19 +259,14 @@ function compilePG(items: Array<SQLItem>, options: {minify: boolean}): PGQuery {
       // identifier for non-string identifiers.
       case SQLItemType.IDENTIFIER: {
         query.text += item.names
-          .map(
-            (name): string => {
-              if (typeof name === 'string') return escapePGIdentifier(name);
+          .map((name): string => {
+            if (typeof name === 'string') return escapePGIdentifier(name);
 
-              if (!localIdentifiers.has(name))
-                localIdentifiers.set(
-                  name,
-                  `__local_${localIdentifiers.size}__`,
-                );
+            if (!localIdentifiers.has(name))
+              localIdentifiers.set(name, `__local_${localIdentifiers.size}__`);
 
-              return localIdentifiers.get(name)!;
-            },
-          )
+            return localIdentifiers.get(name)!;
+          })
           .join('.');
         break;
       }
@@ -305,19 +310,14 @@ function compileMySQL(items: Array<SQLItem>): MySqlQuery {
       // identifier for non-string identifiers.
       case SQLItemType.IDENTIFIER: {
         query.text += item.names
-          .map(
-            (name): string => {
-              if (typeof name === 'string') return escapeMySqlIdentifier(name);
+          .map((name): string => {
+            if (typeof name === 'string') return escapeMySqlIdentifier(name);
 
-              if (!localIdentifiers.has(name))
-                localIdentifiers.set(
-                  name,
-                  `__local_${localIdentifiers.size}__`,
-                );
+            if (!localIdentifiers.has(name))
+              localIdentifiers.set(name, `__local_${localIdentifiers.size}__`);
 
-              return localIdentifiers.get(name)!;
-            },
-          )
+            return localIdentifiers.get(name)!;
+          })
           .join('.');
         break;
       }

--- a/packages/sql/src/__tests__/fixture.sql
+++ b/packages/sql/src/__tests__/fixture.sql
@@ -1,0 +1,1 @@
+SELECT * FROM my_table;

--- a/packages/sql/src/__tests__/index.test.ts
+++ b/packages/sql/src/__tests__/index.test.ts
@@ -17,6 +17,7 @@ Object {
 }
 `);
 });
+
 test('can join parts of query', () => {
   const conditions = [
     sql`id = ${10}`,
@@ -34,6 +35,16 @@ Object {
     10,
     2018-12-19T16:53:20.939Z,
   ],
+}
+`);
+});
+
+test('can read in a file', () => {
+  const query = sql.file(`${__dirname}/fixture.sql`);
+  expect(query.compile()).toMatchInlineSnapshot(`
+Object {
+  "text": "SELECT * FROM my_table;",
+  "values": Array [],
 }
 `);
 });

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -10,6 +10,7 @@ export interface SQL {
 
   join(queries: Array<SQLQuery>, seperator?: string): SQLQuery;
   __dangerous__rawValue(text: string): SQLQuery;
+  file(filename: string): SQLQuery;
   value(value: any): SQLQuery;
   ident(...names: Array<any>): SQLQuery;
   registerFormatter<T>(
@@ -26,6 +27,7 @@ const modifiedSQL: SQL = Object.assign(
     // tslint:disable:no-unbound-method
     join: SQLQuery.join,
     __dangerous__rawValue: SQLQuery.raw,
+    file: SQLQuery.file,
     value: SQLQuery.value,
     ident: SQLQuery.ident,
     registerFormatter: SQLQuery.registerFormatter,

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/sql": "^1.0.3",
+    "@databases/sql": "^1.1.0",
     "@types/sqlite3": "^3.1.5",
     "sqlite3": "^4.0.6",
     "then-queue": "^1.3.0"

--- a/packages/websql-core/package.json
+++ b/packages/websql-core/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/sql": "^1.0.3"
+    "@databases/sql": "^1.1.0"
   },
   "scripts": {},
   "repository": "https://github.com/ForbesLindesay/atdatabases/tree/master/packages/websql-core",


### PR DESCRIPTION
This reads a file containing an SQL query in utf8 text, and returns it as an SQLQuery. It's generally most useful for large blocks of SQL, like database migrations.

```ts
const migration = sql.file(`${__dirname}/my-migration.sql`);
db.query(migration);
```

> N.B. if you allow users to write to the files that you later read in as queries via this method, your code will be vulnerable to SQL Injeciton. Only read in trusted files created by your own team of developers.

[closes #35]