### PR TITLE
feat: error on quoted values (BREAKING CHANGE)

### DIFF
--- a/packages/sql/src/SQLQuery.ts
+++ b/packages/sql/src/SQLQuery.ts
@@ -100,6 +100,15 @@ export default class SQLQuery implements PGQuery {
             }
             for (const item of formatted._items) items.push(item);
           } else {
+            if (
+              strings[i + 1] &&
+              strings[i + 1].startsWith("'") &&
+              strings[i].endsWith("'")
+            ) {
+              throw new Error(
+                `You do not need to wrap values in 'quotes' when using @databases. Any JavaScript string passed via \${...} syntax is already treated as a string. Please remove the quotes around this value.`,
+              );
+            }
             items.push({type: SQLItemType.VALUE, value});
           }
         }


### PR DESCRIPTION
BREAKING CHANGE: if you were using values with quotes around them to construct an SQL query, that will now error. This shouldn't cause any issues as the resulting query would not have been valid anyway.