### PR TITLE
fix: changed TransactionMode to be taken from pg.txMode rather than pg

### DIFF
--- a/packages/pg/src/index.ts
+++ b/packages/pg/src/index.ts
@@ -217,7 +217,7 @@ class ConnectionImplementation {
         opts.tag = tag;
       }
       if (Object.keys(txMode).length) {
-        opts.mode = new pg.TransactionMode(
+        opts.mode = new pg.txMode.TransactionMode(
           txMode.isolationLevel,
           txMode.readOnly,
           txMode.deferrable,


### PR DESCRIPTION
This is to fix the below bug:

```
TypeError: pg.TransactionMode is not a constructor
          at ConnectionPoolImplementation.<anonymous> (/Users/samhouse/threads/product-catalogue-api/node_modules/@databases/pg/src/index.ts:172:4)
          at Generator.next (<anonymous>)
          at /Users/samhouse/threads/product-catalogue-api/node_modules/@databases/pg/src/index.ts:3:51
          at new Promise (<anonymous>)
          at Object.<anonymous>.__awaiter (/Users/samhouse/threads/product-catalogue-api/node_modules/@databases/pg/lib/index.js:4:12)
          at ConnectionPoolImplementation.tx (/Users/samhouse/threads/product-catalogue-api/node_modules/@databases/pg/lib/index.js:114:16)
          at Object.tx (/Users/samhouse/threads/product-catalogue-api/node_modules/@threads/pg-ssm/src/index.ts:70:32)
          at process._tickCallback (internal/process/next_tick.js:68:7)
```