### PR TITLE
feat: support CommonJS in MySQL and SQLite

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -10,6 +10,9 @@ The `@databases/mysql` library provides a safe and convenient API for querying M
 
 ```ts
 import connect, {sql} from '@databases/mysql';
+// or in CommonJS:
+// const connect = require('@databases/mysql');
+// const {sql} = require('@databases/mysql');
 
 const db = connect();
 

--- a/docs/pg.md
+++ b/docs/pg.md
@@ -10,6 +10,9 @@ The `@databases/pg` library provides a safe and convenient API for querying post
 
 ```ts
 import connect, {sql} from '@databases/pg';
+// or in CommonJS:
+// const connect = require('@databases/pg');
+// const {sql} = require('@databases/pg');
 
 const db = connect();
 

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -12,6 +12,9 @@ N.B. you should only have one process connected to a given SQLite database at a 
 
 ```ts
 import connect, {sql} from '@databases/sqlite';
+// or in CommonJS:
+// const connect = require('@databases/sqlite');
+// const {sql} = require('@databases/sqlite');
 
 const db = connect();
 

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -144,7 +144,7 @@ export default function connect(
   return new DatabaseConnectionImplementation(filename, options);
 }
 module.exports = Object.assign(connect, {
-  defualt: connect,
+  default: connect,
   DatabaseConnectionMode,
   IN_MEMORY,
   sql,


### PR DESCRIPTION
BREAKING CHANGE: we now export interfaces rather than classes. This makes more sense as we don't want people to construct/interact with the classes directly.