### PR TITLE
feat: deprecate passing strings to sql.join

### DIFF
--- a/docs/sql.md
+++ b/docs/sql.md
@@ -76,7 +76,7 @@ const arrayOfSqlFields = ["a", "b", "c", "d"].map(
   n => sql.identifier(n),
 );
 
-sql`SELECT ${sql.join(arrayOfSqlFields, ", ")}`;
+sql`SELECT ${sql.join(arrayOfSqlFields, sql`, `)}`;
 // => {text: 'SELECT "a", "b", "c", "d";', values: []}
 
 const arrayOfSqlConditions = [
@@ -84,7 +84,7 @@ const arrayOfSqlConditions = [
   sql.query`b = ${2}`,
   sql.query`c = ${3}`
 ];
-sql`WHERE (${sql.join(arrayOfSqlConditions, ') AND (')})`;
+sql`WHERE (${sql.join(arrayOfSqlConditions, sql`) AND (`)})`;
 // => {text: 'WHERE (a = $1) AND (b = $2) AND (c = $3)', values: [1, 2, 3]}
 ```
 

--- a/packages/mysql/src/__tests__/stream.test.ts
+++ b/packages/mysql/src/__tests__/stream.test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
     }
     await db.query(sql`
       INSERT INTO streaming_test_values (id)
-      VALUES ${sql.join(batchValues.map(v => sql`(${v})`), ',')};
+      VALUES ${sql.join(batchValues.map(v => sql`(${v})`), sql`,`)};
     `);
   }
 });

--- a/packages/pg-schema/src/getAttributes.ts
+++ b/packages/pg-schema/src/getAttributes.ts
@@ -57,7 +57,9 @@ export default async function getAttributes(
       ON (cls.relnamespace = ns.oid)
     LEFT OUTER JOIN pg_catalog.pg_attrdef def -- default values
       ON (def.adrelid = cls.oid AND def.adnum = a.attnum)
-    ${conditions.length ? sql`WHERE ${sql.join(conditions, ' AND ')}` : sql``}
+    ${
+      conditions.length ? sql`WHERE ${sql.join(conditions, sql` AND `)}` : sql``
+    }
   `);
 
   return attributes;

--- a/packages/pg-schema/src/getClasses.ts
+++ b/packages/pg-schema/src/getClasses.ts
@@ -33,7 +33,9 @@ export default async function getClasses(
     FROM pg_catalog.pg_class cls
     INNER JOIN pg_catalog.pg_namespace ns
       ON (cls.relnamespace = ns.oid)
-    ${conditions.length ? sql`WHERE ${sql.join(conditions, ' AND ')}` : sql``}
+    ${
+      conditions.length ? sql`WHERE ${sql.join(conditions, sql` AND `)}` : sql``
+    }
     ORDER BY cls.relname;
   `);
 
@@ -45,7 +47,10 @@ export function classQuery(query: ClassQuery) {
   if (query.kind) {
     if (Array.isArray(query.kind)) {
       conditions.push(
-        sql`cls.relkind IN (${sql.join(query.kind.map(k => sql`${k}`), ', ')})`,
+        sql`cls.relkind IN (${sql.join(
+          query.kind.map(k => sql`${k}`),
+          sql`, `,
+        )})`,
       );
     } else {
       conditions.push(sql`cls.relkind = ${query.kind}`);

--- a/packages/pg-schema/src/getConstraints.ts
+++ b/packages/pg-schema/src/getConstraints.ts
@@ -54,7 +54,9 @@ export default async function getConstraints(
       ON (c.conindid = cls.oid)
     INNER JOIN pg_catalog.pg_namespace ns
       ON (c.connamespace = ns.oid)
-    ${conditions.length ? sql`WHERE ${sql.join(conditions, ' AND ')}` : sql``}
+    ${
+      conditions.length ? sql`WHERE ${sql.join(conditions, sql` AND `)}` : sql``
+    }
   `);
 
   return constraints;

--- a/packages/pg-schema/src/getEnumValues.ts
+++ b/packages/pg-schema/src/getEnumValues.ts
@@ -28,7 +28,9 @@ export default async function getEnumValues(
       ON (ty.typnamespace = ns.oid)
     LEFT OUTER JOIN pg_catalog.pg_type subt
       ON (ty.typelem = subt.oid)
-    ${conditions.length ? sql`WHERE ${sql.join(conditions, ' AND ')}` : sql``}
+    ${
+      conditions.length ? sql`WHERE ${sql.join(conditions, sql` AND `)}` : sql``
+    }
   `);
 
   return enumValues;

--- a/packages/pg-schema/src/getTypes.ts
+++ b/packages/pg-schema/src/getTypes.ts
@@ -103,7 +103,9 @@ export default async function getTypes(
       ON (ty.typelem = subt.oid)
     LEFT OUTER JOIN pg_catalog.pg_type baset
       ON (ty.typbasetype = baset.oid)
-    ${conditions.length ? sql`WHERE ${sql.join(conditions, ' AND ')}` : sql``}
+    ${
+      conditions.length ? sql`WHERE ${sql.join(conditions, sql` AND `)}` : sql``
+    }
   `)) as TypeRecord[];
 
   return Promise.all(

--- a/packages/pg/src/__tests__/stream.test.ts
+++ b/packages/pg/src/__tests__/stream.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
     }
     await db.query(sql`
       INSERT INTO streaming_test.values (id)
-      VALUES ${sql.join(batchValues.map(v => sql`(${v})`), ',')};
+      VALUES ${sql.join(batchValues.map(v => sql`(${v})`), sql`,`)};
     `);
   }
 });

--- a/packages/sql/src/SQLQuery.ts
+++ b/packages/sql/src/SQLQuery.ts
@@ -1,6 +1,7 @@
 import minify = require('pg-minify');
 import {readFileSync} from 'fs';
 
+const warnedJoinSeparators = new Set<string>();
 /**
  * A Postgres query which may be fed directly into the `pg` module for
  * execution.
@@ -109,26 +110,66 @@ export default class SQLQuery implements PGQuery {
     return new SQLQuery(items);
   }
 
+  // tslint:disable:unified-signatures
   /**
-   * Joins multiple queries together and puts a seperator in between if a
-   * seperator was defined.
+   * Joins multiple queries together and puts a separator in between if a
+   * separator was defined.
    */
-  public static join(queries: Array<SQLQuery>, seperator?: string) {
+  public static join(queries: Array<SQLQuery>, separator?: SQLQuery): SQLQuery;
+  /**
+   * Joins multiple queries together and puts a separator in between if a
+   * separator was defined.
+   */
+  public static join(
+    queries: Array<SQLQuery>,
+    separator: ',' | ', ' | ' AND ' | ' OR ',
+  ): SQLQuery;
+  /**
+   * Joins multiple queries together and puts a separator in between if a
+   * separator was defined.
+   *
+   * @deprecated please do not pass the separator as a string, use sql`` to mark it as an SQL string
+   */
+  public static join(queries: Array<SQLQuery>, separator: string): SQLQuery;
+  public static join(
+    queries: Array<SQLQuery>,
+    separator?: string | SQLQuery,
+  ): SQLQuery {
+    if (
+      typeof separator === 'string' &&
+      ![',', ', ', ' AND ', ' OR ', ') AND (', ') OR ('].includes(separator) &&
+      !warnedJoinSeparators.has(separator)
+    ) {
+      warnedJoinSeparators.add(separator);
+      const err = new Error(
+        `Passing join separators as a string is deprecated, please tag your string as an SQL query via "sql.join(..., sql\`${
+          separator.includes('`') ? 'your_separator' : separator
+        }\`)"`,
+      );
+      err.message = 'Deprecation Warning';
+      console.warn(err.stack);
+    }
     const items: Array<SQLItem> = [];
+    const separatorItems: SQLItem[] | undefined = separator
+      ? typeof separator === 'string'
+        ? [{type: SQLItemType.RAW, text: separator}]
+        : separator._items
+      : undefined;
 
     // Add the items of all our queries into the `items` array, adding text
-    // seperator items as necessary.
+    // separator items as necessary.
     for (const query of queries) {
       for (const item of query._items) items.push(item);
 
-      // If we have a seperator, and this is not the last query, add a
-      // seperator.
-      if (seperator && query !== queries[queries.length - 1])
-        items.push({type: SQLItemType.RAW, text: seperator});
+      // If we have a separator, and this is not the last query, add a
+      // separator.
+      if (separatorItems && query !== queries[queries.length - 1])
+        items.push(...separatorItems);
     }
 
     return new SQLQuery(items);
   }
+  // tslint:enable:unified-signatures
 
   /**
    * Creates a new query with the contents of a utf8 file

--- a/packages/sql/src/__tests__/index.test.ts
+++ b/packages/sql/src/__tests__/index.test.ts
@@ -26,7 +26,7 @@ test('can join parts of query', () => {
   const query = sql`
       SELECT *
       FROM foo
-      WHERE ${sql.join(conditions, ' AND ')};
+      WHERE ${sql.join(conditions, sql` AND `)};
   `;
   expect(query.compile()).toMatchInlineSnapshot(`
 Object {

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -8,7 +8,28 @@ export {SQLQuery};
 export interface SQL {
   (strings: TemplateStringsArray, ...values: Array<any>): SQLQuery;
 
-  join(queries: Array<SQLQuery>, seperator?: string): SQLQuery;
+  // tslint:disable:unified-signatures
+  /**
+   * Joins multiple queries together and puts a separator in between if a
+   * separator was defined.
+   */
+  join(queries: Array<SQLQuery>, separator?: SQLQuery): SQLQuery;
+  /**
+   * Joins multiple queries together and puts a separator in between if a
+   * separator was defined.
+   */
+  join(
+    queries: Array<SQLQuery>,
+    separator: ',' | ', ' | ' AND ' | ' OR ',
+  ): SQLQuery;
+  /**
+   * Joins multiple queries together and puts a separator in between if a
+   * separator was defined.
+   *
+   * @deprecated please do not pass the separator as a string, use sql`` to mark it as an SQL string
+   */
+  join(queries: Array<SQLQuery>, separator: string): SQLQuery;
+  // tslint:enable:unified-signatures
   __dangerous__rawValue(text: string): SQLQuery;
   file(filename: string): SQLQuery;
   value(value: any): SQLQuery;
@@ -25,6 +46,7 @@ const modifiedSQL: SQL = Object.assign(
     SQLQuery.query(strings, ...values),
   {
     // tslint:disable:no-unbound-method
+    // tslint:disable-next-line:deprecation
     join: SQLQuery.join,
     __dangerous__rawValue: SQLQuery.raw,
     file: SQLQuery.file,

--- a/packages/sqlite/src/__tests__/stream.test.ts
+++ b/packages/sqlite/src/__tests__/stream.test.ts
@@ -18,7 +18,7 @@ test('streaming', async () => {
     }
     await db.query(sql`
       INSERT INTO stream_values (id)
-      VALUES ${sql.join(batchValues.map(v => sql`(${v})`), ',')};
+      VALUES ${sql.join(batchValues.map(v => sql`(${v})`), sql`,`)};
     `);
   }
   const results = [];


### PR DESCRIPTION
[closes #36]

For now, we don't actually break code that uses string literal delimiters, but we do log a warning to the console, so I'm going to treat this as a breaking change anyway.