### PR TITLE
chore: release packages

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databases/expo",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/websql-core": "^2.0.1"
+    "@databases/websql-core": "^3.0.0"
   },
   "peerDependencies": {
     "expo-sqlite": "*"

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databases/mysql",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -8,7 +8,7 @@
     "@babel/code-frame": "^7.0.0",
     "@databases/mysql-config": "^1.0.1",
     "@databases/push-to-async-iterable": "^1.0.0",
-    "@databases/sql": "^1.1.0",
+    "@databases/sql": "^2.0.0",
     "@types/mysql": "^2.15.5",
     "mysql2": "^1.6.4"
   },

--- a/packages/pg-create/package.json
+++ b/packages/pg-create/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databases/pg-create",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/pg": "^1.2.0",
+    "@databases/pg": "^2.0.0",
     "@types/rimraf": "^2.0.2",
     "chalk": "^2.4.1",
     "cross-spawn": "^6.0.5",

--- a/packages/pg-migrations/package.json
+++ b/packages/pg-migrations/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databases/pg-migrations",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/pg": "^1.2.0",
+    "@databases/pg": "^2.0.0",
     "chalk": "^2.4.1",
     "prettier": "^1.15.3"
   },

--- a/packages/pg-schema/package.json
+++ b/packages/pg-schema/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@databases/pg-schema",
   "private": true,
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/pg": "^1.2.0"
+    "@databases/pg": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^10.12.17",

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databases/pg",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -10,7 +10,7 @@
     "@databases/pg-data-type-id": "^0.0.1",
     "@databases/pg-errors": "^0.0.1",
     "@databases/push-to-async-iterable": "^1.0.0",
-    "@databases/sql": "^1.1.0",
+    "@databases/sql": "^2.0.0",
     "@types/pg-query-stream": "^1.0.2",
     "pg-promise": "^8.6.0",
     "pg-query-stream": "1.1.2"

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databases/sql",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databases/sqlite",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/sql": "^1.1.0",
+    "@databases/sql": "^2.0.0",
     "@types/sqlite3": "^3.1.5",
     "sqlite3": "^4.0.6",
     "then-queue": "^1.3.0"

--- a/packages/websql-core/package.json
+++ b/packages/websql-core/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databases/websql-core",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/sql": "^1.1.0"
+    "@databases/sql": "^2.0.0"
   },
   "scripts": {},
   "repository": "https://github.com/ForbesLindesay/atdatabases/tree/master/packages/websql-core",

--- a/packages/websql/package.json
+++ b/packages/websql/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databases/websql",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "@databases/websql-core": "^2.0.1",
+    "@databases/websql-core": "^3.0.0",
     "websql": "^1.0.0"
   },
   "scripts": {},


### PR DESCRIPTION
expo 2.0.1 -> 3.0.0
mysql 1.1.0 -> 2.0.0
pg 1.2.0 -> 2.0.0
sql 1.1.0 -> 2.0.0
sqlite 1.1.0 -> 2.0.0
websql-core 2.0.1 -> 3.0.0
websql 2.0.1 -> 3.0.0