### PR TITLE
fix: do not pass common-env context to non-master builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ workflows:
   all:
     jobs:
       - all:
-          context: common-env
           filters:
             branches:
               ignore:


### PR DESCRIPTION
It isn't needed and it prevents the build from running.