### PR TITLE
Support external docker

### DIFF
--- a/packages/with-container/src/index.ts
+++ b/packages/with-container/src/index.ts
@@ -11,6 +11,7 @@ export interface Options {
   image: string;
   containerName: string;
   defaultExternalPort: number;
+  host?: string;
   externalPort?: number;
   internalPort: number;
   connectTimeoutSeconds: number;
@@ -119,7 +120,7 @@ export async function waitForDatabaseToStart(options: NormalizedOptions) {
       console.warn(
         `Waiting for ${options.containerName} on port ${options.externalPort}...`,
       );
-      const connection = connect(options.externalPort)
+      const connection = connect(options.externalPort, options.host)
         .on('error', () => {
           if (finished) return;
           setTimeout(test, 500);


### PR DESCRIPTION
I'm running on GitLab and trying to use Docker to run a PG database for testing.

In GitLab, CI pipelines are executed inside of Docker containers (rather than within dedicated VMs as is the case with Travis-CI) so you can't start a nested docker daemon. However, they **do** support launching a "sidecar" docker service at `tcp://docker:2375`. This means that all started containers aren't available at localhost, but rather, at the `docker` host.