### PR TITLE
fix: support update in pg-typed

### DIFF
--- a/packages/sql/src/SQLQuery.ts
+++ b/packages/sql/src/SQLQuery.ts
@@ -410,7 +410,7 @@ function escapePGIdentifier(str: string): string {
   }
   if (!/^[A-Za-z0-9_]*$/.test(str)) {
     throw new Error(
-      '@database/sql restricts postgres identifiers to alphanumeric characers and underscores.',
+      `@database/sql restricts postgres identifiers to alphanumeric characers and underscores. "${str}" is not allowed`,
     );
   }
 


### PR DESCRIPTION
The syntax was wrong for `update` and `insertOrUpdate`. Both of these now have tests.