### PR TITLE
fix: do not verify ssl certificates when no certs were provided

### DIFF
--- a/packages/pg/src/index.ts
+++ b/packages/pg/src/index.ts
@@ -329,7 +329,12 @@ function getSSLConfig(
   }
   if (
     config.ssl === 'no-verify' ||
-    (parsedConnectionString.sslmode === 'no-verify' && !config.ssl)
+    (!config.ssl && parsedConnectionString.sslmode === 'no-verify') ||
+    !(
+      parsedConnectionString.sslcert ||
+      parsedConnectionString.sslkey ||
+      parsedConnectionString.sslrootcert
+    )
   ) {
     ssl.rejectUnauthorized = false;
   }


### PR DESCRIPTION
This is a closer match for the default behaviour of most postgres clients. You can still perform ssl verification by providing `sslcert`, `sslkey`, `sslrootcert` or by specifying the ssl options when constructing the client.