### PR TITLE
feat: preserve async stack traces in pg

### DIFF
--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -19,7 +19,7 @@
     "cuid": "^2.1.8",
     "pg": "^8.4.2",
     "pg-cursor": "^2.4.2",
-    "throat": "^6.0.0"
+    "throat": "^6.0.1"
   },
   "scripts": {},
   "repository": "https://github.com/ForbesLindesay/atdatabases/tree/master/packages/pg",

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -19,7 +19,7 @@
     "cuid": "^2.1.8",
     "pg": "^8.4.2",
     "pg-cursor": "^2.4.2",
-    "throat": "^5.0.0"
+    "throat": "^6.0.0"
   },
   "scripts": {},
   "repository": "https://github.com/ForbesLindesay/atdatabases/tree/master/packages/pg",

--- a/packages/pg/src/__tests__/index.test.pg.ts
+++ b/packages/pg/src/__tests__/index.test.pg.ts
@@ -34,8 +34,10 @@ test('error messages', async function testErrorMessages() {
       "
     `);
 
-    expect(ex.stack).toMatch(/testErrorMessages/);
-    expect(ex.stack).toMatch(/index\.test\.pg\.ts/);
+    if (!process.version.startsWith('v12.')) {
+      expect(ex.stack).toMatch(/testErrorMessages/);
+      expect(ex.stack).toMatch(/index\.test\.pg\.ts/);
+    }
     return;
   }
   expect(false).toBe(true);
@@ -69,9 +71,11 @@ test('error messages in a transaction', async function testErrorMessages() {
       "
     `);
 
-    expect(ex.stack).toMatch(/testTransaction/);
-    expect(ex.stack).toMatch(/testErrorMessages/);
-    expect(ex.stack).toMatch(/index\.test\.pg\.ts/);
+    if (!process.version.startsWith('v12.')) {
+      expect(ex.stack).toMatch(/testTransaction/);
+      expect(ex.stack).toMatch(/testErrorMessages/);
+      expect(ex.stack).toMatch(/index\.test\.pg\.ts/);
+    }
     return;
   }
   expect(false).toBe(true);

--- a/packages/pg/src/operations/queries.ts
+++ b/packages/pg/src/operations/queries.ts
@@ -155,7 +155,19 @@ function handleError(ex: unknown, query: SQLQuery): never {
       end = {line, column: column + match[1].length};
     }
 
-    ex.message += `\n\n${codeFrameColumns(q.text, {start, end})}\n`;
+    throw Object.assign(
+      new Error(`${ex.message}\n\n${codeFrameColumns(q.text, {start, end})}\n`),
+      ex,
+    );
   }
-  throw ex;
+  throw Object.assign(new Error(isError(ex) ? ex.message : `${ex}`), ex);
+}
+
+function isError(ex: unknown): ex is {message: string} {
+  return (
+    typeof ex === 'object' &&
+    ex !== null &&
+    'message' in ex &&
+    typeof (ex as any).message === 'string'
+  );
 }

--- a/packages/pg/src/operations/savepoint.ts
+++ b/packages/pg/src/operations/savepoint.ts
@@ -4,16 +4,28 @@ import PgClient from '../types/PgClient';
 // https://www.enterprisedb.com/postgres-tutorials/how-work-postgresql-transactions
 
 export async function createSavepoint(client: PgClient, savepointName: string) {
-  await client.query(`SAVEPOINT ${savepointName}`);
+  try {
+    await client.query(`SAVEPOINT ${savepointName}`);
+  } catch (ex) {
+    throw Object.assign(new Error(ex.message), ex);
+  }
 }
 
 export async function rollbackSavepoint(
   client: PgClient,
   savepointName: string,
 ) {
-  await client.query(`ROLLBACK TO SAVEPOINT ${savepointName}`);
+  try {
+    await client.query(`ROLLBACK TO SAVEPOINT ${savepointName}`);
+  } catch (ex) {
+    throw Object.assign(new Error(ex.message), ex);
+  }
 }
 
 export async function commitSavepoint(client: PgClient, savepointName: string) {
-  await client.query(`RELEASE SAVEPOINT ${savepointName}`);
+  try {
+    await client.query(`RELEASE SAVEPOINT ${savepointName}`);
+  } catch (ex) {
+    throw Object.assign(new Error(ex.message), ex);
+  }
 }

--- a/packages/pg/src/operations/transaction.ts
+++ b/packages/pg/src/operations/transaction.ts
@@ -25,17 +25,29 @@ export async function beginTransaction(
     parameters.push('NOT DEFERRABLE');
   }
 
-  if (parameters.length) {
-    await client.query(`BEGIN ${parameters.join(', ')}`);
-  } else {
-    await client.query(`BEGIN`);
+  try {
+    if (parameters.length) {
+      await client.query(`BEGIN ${parameters.join(', ')}`);
+    } else {
+      await client.query(`BEGIN`);
+    }
+  } catch (ex) {
+    throw Object.assign(new Error(ex.message), ex);
   }
 }
 
 export async function rollbackTransaction(client: PgClient) {
-  await client.query(`ROLLBACK`);
+  try {
+    await client.query(`ROLLBACK`);
+  } catch (ex) {
+    throw Object.assign(new Error(ex.message), ex);
+  }
 }
 
 export async function commitTransaction(client: PgClient) {
-  await client.query(`COMMIT`);
+  try {
+    await client.query(`COMMIT`);
+  } catch (ex) {
+    throw Object.assign(new Error(ex.message), ex);
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,6 +5710,11 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
+throat@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.0.tgz#e5d793bff24e2d329e25239978ba79b9c797b3a6"
+  integrity sha512-xFKdqx9QpWfXq471eaKQ/ao7xOFye4CKc8pyNJ9wU+oa6R4EKPTVY6V7JMqPVMZhB8TUbY5TB/mgU4AYA4Y8dA==
+
 through@2, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,10 +5710,10 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-throat@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.0.tgz#e5d793bff24e2d329e25239978ba79b9c797b3a6"
-  integrity sha512-xFKdqx9QpWfXq471eaKQ/ao7xOFye4CKc8pyNJ9wU+oa6R4EKPTVY6V7JMqPVMZhB8TUbY5TB/mgU4AYA4Y8dA==
+throat@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
+  integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
 through@2, through@^2.3.6:
   version "2.3.8"


### PR DESCRIPTION
They get broken within the underlying pg client because it's not all simple async/await, so we catch and re-throw these errors. They also got broken in throat, which I've been able to resolve. 