### PR TITLE
fix(pg-test): use proper command line flag in help command output

### DIFF
--- a/packages/mysql-test/src/commands.ts
+++ b/packages/mysql-test/src/commands.ts
@@ -171,9 +171,9 @@ export function help(command?: string) {
       console.info(`                               to start. You can specify a raw number in`);
       console.info(`                               seconds, or a time string like "1 minute"`);
       console.info(`  -r, --refresh                Update the cached docker conatiner`);
-      console.info(`  -user              <string>  The mysql user`);
-      console.info(`  -password          <string>  The mysql password`);
-      console.info(`  -db                <string>  The mysql database`);
+      console.info(`  --user              <string>  The mysql user`);
+      console.info(`  --password          <string>  The mysql password`);
+      console.info(`  --db                <string>  The mysql database`);
       console.info(`  -h, --help                   Show this help message and exit.`);
       break;
     case 'run':
@@ -190,9 +190,9 @@ export function help(command?: string) {
       console.info(`                               to start. You can specify a raw number in`);
       console.info(`                               seconds, or a time string like "1 minute"`);
       console.info(`  -r, --refresh                Update the cached docker conatiner`);
-      console.info(`  -user              <string>  The mysql user`);
-      console.info(`  -password          <string>  The mysql password`);
-      console.info(`  -db                <string>  The mysql database`);
+      console.info(`  --user              <string>  The mysql user`);
+      console.info(`  --password          <string>  The mysql password`);
+      console.info(`  --db                <string>  The mysql database`);
       console.info(`  -h, --help                   Show this help message and exit.`);
       break;
     case 'stop':

--- a/packages/pg-test/src/commands.ts
+++ b/packages/pg-test/src/commands.ts
@@ -170,7 +170,6 @@ export function help(command?: string) {
       console.info(`                               seconds, or a time string like "1 minute"`);
       console.info(`  -r, --refresh                Update the cached docker conatiner`);
       console.info(`  --user              <string> The Postgres user`);
-      console.info(`  -password          <string>  The Postgres password`);
       console.info(`  --db                <string> The Postgres database`);
       console.info(`  -h, --help                   Show this help message and exit.`);
       break;

--- a/packages/pg-test/src/commands.ts
+++ b/packages/pg-test/src/commands.ts
@@ -162,16 +162,16 @@ export function help(command?: string) {
       console.info(``);
       console.info(`Optional arguments:`);
       console.info(`  -d, --debug                  Print all the output of child commands.`);
-      console.info(`  --image            <string>  Override the MySQL docker image.`);
+      console.info(`  --image            <string>  Override the Postgres docker image.`);
       console.info(`  --containerName    <string>  Specify a custom name for the container.`);
       console.info(`  -p, --externalPort <integer> Specify the port to run on.`);
       console.info(`  --connectTimeout   <seconds> How long should we allow for the container`);
       console.info(`                               to start. You can specify a raw number in`);
       console.info(`                               seconds, or a time string like "1 minute"`);
       console.info(`  -r, --refresh                Update the cached docker conatiner`);
-      console.info(`  -user              <string>  The pg user`);
-      console.info(`  -password          <string>  The pg password`);
-      console.info(`  -db                <string>  The pg database`);
+      console.info(`  --user              <string> The Postgres user`);
+      console.info(`  -password          <string>  The Postgres password`);
+      console.info(`  --db                <string> The Postgres database`);
       console.info(`  -h, --help                   Show this help message and exit.`);
       break;
     case 'run':
@@ -188,8 +188,8 @@ export function help(command?: string) {
       console.info(`                               to start. You can specify a raw number in`);
       console.info(`                               seconds, or a time string like "1 minute"`);
       console.info(`  -r, --refresh                Update the cached docker conatiner`);
-      console.info(`  -user              <string>  The postgres user`);
-      console.info(`  -db                <string>  The postgres database`);
+      console.info(`  --user              <string> The Postgres user`);
+      console.info(`  --db                <string> The Postgres database`);
       console.info(`  -h, --help                   Show this help message and exit.`);
       break;
     case 'stop':


### PR DESCRIPTION
In particular, this changes the help output to give the proper flags for changing the PG user and database (`--user` and `--database` rather than `-user` and `-database`, respectively). Also fixes some other minor inconsistencies in the help command output.