### PR TITLE
feat: add a utility for queueing an action after commit

### DIFF
--- a/docs/mysql-queryable.md
+++ b/docs/mysql-queryable.md
@@ -85,3 +85,11 @@ If the `Queryable` is a `Connection` or `ConnectionPool`, this will create a tru
 If the `Queryable` is a `ConnectionPool`, this will allocate a connection for the duration of the callback function.
 
 If the `Queryable` is already a `Connection` or `Transaction`, this will simply call the callaback with the existing connection.
+
+### `Queryable.addPostCommitStep(fn): Promise<void>`
+
+If the Queryable is part of a transaction, queue `fn` to be called after the top-level transaction is successfully committed.
+
+If the Queryable is not part of a transaction, call `fn` immediately and `await` the result.
+
+This function can be useful for clearing caches after transactions are committed.

--- a/docs/mysql-transaction.md
+++ b/docs/mysql-transaction.md
@@ -75,3 +75,7 @@ const result = await db.task(async (db) => {
 ### `Transaction.task(fn): Promise<T>`
 
 This method exists to mimic the API in `ConnectionPool.task`. It does not allocate a fresh connection or transaction, and simply returns `fn(this)`.
+
+### `Transaction.addPostCommitStep(fn): Promise<void>`
+
+Queue `fn` to be called after the top-level transaction is successfully committed. If this transaction is nested inside another transaction, `fn` will not be called until the outer most transaction has been committed. This can be used to clear caches after updating values.

--- a/docs/pg-queryable.md
+++ b/docs/pg-queryable.md
@@ -85,3 +85,11 @@ If the `Queryable` is a `Connection` or `ConnectionPool`, this will create a tru
 If the `Queryable` is a `ConnectionPool`, this will allocate a connection for the duration of the callback function.
 
 If the `Queryable` is already a `Connection` or `Transaction`, this will simply call the callaback with the existing connection.
+
+### `Queryable.addPostCommitStep(fn): Promise<void>`
+
+If the Queryable is part of a transaction, queue `fn` to be called after the top-level transaction is successfully committed.
+
+If the Queryable is not part of a transaction, call `fn` immediately and `await` the result.
+
+This function can be useful for clearing caches after transactions are committed.

--- a/docs/pg-transaction.md
+++ b/docs/pg-transaction.md
@@ -75,3 +75,7 @@ const result = await db.task(async (db) => {
 ### `Transaction.task(fn): Promise<T>`
 
 This method exists to mimic the API in `ConnectionPool.task`. It does not allocate a fresh connection or transaction, and simply returns `fn(this)`.
+
+### `Transaction.addPostCommitStep(fn): Promise<void>`
+
+Queue `fn` to be called after the top-level transaction is successfully committed. If this transaction is nested inside another transaction, `fn` will not be called until the outer most transaction has been committed. This can be used to clear caches after updating values.

--- a/packages/mock-db/src/ConnectionPool.ts
+++ b/packages/mock-db/src/ConnectionPool.ts
@@ -9,8 +9,8 @@ import MockDbDriver from './Driver';
 import MockDbOptions from './types/MockDbOptions';
 
 const factories: Factory<MockDbDriver, Connection, Transaction> = {
-  createTransaction(driver) {
-    return new Transaction(driver, factories);
+  createTransaction(driver, transactionParentContext) {
+    return new Transaction(driver, factories, transactionParentContext);
   },
   createConnection(driver) {
     return new Connection(driver, factories);

--- a/packages/mysql/src/ConnectionPool.ts
+++ b/packages/mysql/src/ConnectionPool.ts
@@ -9,8 +9,8 @@ import EventHandlers from './types/EventHandlers';
 import MySqlDriver from './MySqlDriver';
 
 const factories: Factory<MySqlDriver, Connection, Transaction> = {
-  createTransaction(driver) {
-    return new Transaction(driver, factories);
+  createTransaction(driver, transactionParentContext) {
+    return new Transaction(driver, factories, transactionParentContext);
   },
   createConnection(driver) {
     return new Connection(driver, factories);

--- a/packages/mysql/src/types/Queryable.ts
+++ b/packages/mysql/src/types/Queryable.ts
@@ -19,6 +19,7 @@ export default interface Queryable {
     fn: (connection: Transaction) => Promise<T>,
     options?: TransactionOptions,
   ): Promise<T>;
+  addPostCommitStep(fn: () => Promise<void>): Promise<void>;
 }
 
 /**

--- a/packages/pg/src/ConnectionPool.ts
+++ b/packages/pg/src/ConnectionPool.ts
@@ -17,8 +17,8 @@ import createConnectionSource, {PgOptions} from './ConnectionSource';
 import definePrecondition from './definePrecondition';
 
 const factories: Factory<PgDriver, Connection, Transaction> = {
-  createTransaction(driver) {
-    return new Transaction(driver, factories);
+  createTransaction(driver, transactionParentContext) {
+    return new Transaction(driver, factories, transactionParentContext);
   },
   createConnection(driver) {
     return new Connection(driver, factories);

--- a/packages/pg/src/types/Queryable.ts
+++ b/packages/pg/src/types/Queryable.ts
@@ -25,6 +25,7 @@ export default interface Queryable {
     fn: (connection: Transaction) => Promise<T>,
     options?: TransactionOptions,
   ): Promise<T>;
+  addPostCommitStep(fn: () => Promise<void>): Promise<void>;
 }
 
 /**

--- a/packages/shared/src/BaseConnection.ts
+++ b/packages/shared/src/BaseConnection.ts
@@ -96,6 +96,10 @@ export default class BaseConnection<
     }
   }
 
+  async addPostCommitStep(fn: () => Promise<void>): Promise<void> {
+    await fn();
+  }
+
   async *queryStream(
     query: SQLQuery,
     options?: QueryStreamOptions<TDriver>,

--- a/packages/shared/src/BaseConnectionPool.ts
+++ b/packages/shared/src/BaseConnectionPool.ts
@@ -120,6 +120,10 @@ export default class BaseConnectionPool<
     }
   }
 
+  async addPostCommitStep(fn: () => Promise<void>): Promise<void> {
+    await fn();
+  }
+
   async *queryStream(
     query: SQLQuery,
     options?: QueryStreamOptions<TDriver>,

--- a/packages/shared/src/Factory.ts
+++ b/packages/shared/src/Factory.ts
@@ -1,8 +1,15 @@
+export interface TransactionParentContext {
+  addPostCommitStep: (fn: () => Promise<void>) => void;
+}
+
 export interface Disposable {
   dispose(): Promise<void>;
 }
 export interface TransactionFactory<TDriver, TTransaction extends Disposable> {
-  createTransaction(driver: TDriver): TTransaction;
+  createTransaction(
+    driver: TDriver,
+    ctx: TransactionParentContext,
+  ): TTransaction;
 }
 export interface ConnectionFactory<TDriver, TConnection extends Disposable> {
   createConnection(driver: TDriver): TConnection;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 import type {SQLQuery} from '@databases/sql';
 import {Lock} from '@databases/lock';
 import Factory, {
+  TransactionParentContext,
   Disposable,
   ConnectionFactory,
   TransactionFactory,
@@ -18,6 +19,7 @@ export type {SQLQuery, PoolOptions};
 export type {
   Driver,
   Disposable,
+  TransactionParentContext,
   TransactionFactory,
   ConnectionFactory,
   Factory,


### PR DESCRIPTION
This lets you add a "post commit" step. This can be used for clearing caches after updating values.