### PR TITLE
fix: remove tiny-invariant

### DIFF
--- a/packages/mock-db-typed/package.json
+++ b/packages/mock-db-typed/package.json
@@ -4,9 +4,7 @@
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "dependencies": {
-    "tiny-invariant": "^1.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@databases/mock-db": "^0.0.0"
   },

--- a/packages/mock-db-typed/src/index.ts
+++ b/packages/mock-db-typed/src/index.ts
@@ -1,5 +1,4 @@
 import type {sql, SQLQuery, Queryable} from '@databases/mock-db';
-import invariant from 'tiny-invariant';
 
 export interface SelectQuery<TRecord> {
   all(): Promise<TRecord[]>;
@@ -145,10 +144,11 @@ class SelectQueryImplementation<TRecord>
 
   private _methodCalled: string | undefined;
   private async _getResults(mode: string) {
-    invariant(
-      !this._methodCalled,
-      `You cannot use the same query multiple times. ${this._methodCalled} has already been called on this query.`,
-    );
+    if (this._methodCalled) {
+      throw new Error(
+        `You cannot use the same query multiple times. ${this._methodCalled} has already been called on this query.`,
+      );
+    }
     this._methodCalled = mode;
 
     const sql = this._sql;
@@ -372,7 +372,11 @@ class Table<TRecord, TInsertParameters> {
   // throws if > 1 row matches
   async findOne(whereValues: WhereCondition<TRecord>): Promise<TRecord | null> {
     const rows = await this.find(whereValues).all();
-    invariant(rows.length < 2, 'more than one row matched this query');
+    if (rows.length >= 2) {
+      throw new Error(
+        'More than one row matched this query but you used `.findOne`.',
+      );
+    }
     if (rows.length !== 1) {
       return null;
     }

--- a/packages/pg-typed/package.json
+++ b/packages/pg-typed/package.json
@@ -4,9 +4,7 @@
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "dependencies": {
-    "tiny-invariant": "^1.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@databases/pg": "^0.0.0",
     "@databases/pg-schema-print-types": "^0.0.0"


### PR DESCRIPTION
It causes completely useless errors to be thrown in production. It may make sense for client side JavaScript, but for node.js you want the actual error message to be shown.