### PR TITLE
feat(pg-typed): route queries to primary or replica connections

### DIFF
--- a/docs/pg-typed.md
+++ b/docs/pg-typed.md
@@ -45,7 +45,7 @@ The objects returned by the `tables` function are initialized with an optional a
 
 The initializer argument can be a single `ConnectionPool`, `Connection` or `Transaction`.
 
-The initializer argument can also be an array of the same types. If an array is sent, then the first value in the array is treated as the primary connection and is being used only for write queries, while the rest of the connections are used only for read queries. This is useful in a PostgreSQL cluster with primary and read replicas.
+The initializer argument can also be an array of the same types. If an array is sent, then the first value in the array is treated as the primary connection and is only used for write queries, while the rest of the connections are used for read queries. This is useful in a PostgreSQL cluster with primary and read replicas.
 
 ```typescript
 import db, {users} from './database';

--- a/docs/pg-typed.md
+++ b/docs/pg-typed.md
@@ -39,6 +39,32 @@ module.exports = {users, posts};
 
 ## Table
 
+### initializer
+
+The objects returned by the `tables` function are initialized with an optional argument represeting the connection(s) for the queries.
+
+The initializer argument can be a single `ConnectionPool`, `Connection` or `Transaction`.
+
+The initializer argument can also be an array of the same types. If an array is sent, then the first value in the array is treated as the primary connection and is being used only for write queries, while the rest of the connections are used only for read queries. This is useful in a PostgreSQL cluster with primary and read replicas.
+
+```typescript
+import db, {users} from './database';
+
+export async function initialize() {
+  // both queries are run on the same connection
+  await users(db).find().all();
+  await users(db).insert({email: `alice@example.com`, favorite_color: `blue`});
+
+  // read queries are run on the replica connection(s)
+  await users([primary, replica]).find().all();
+  // write queries are run on the primary connection
+  await users([primary, replica]).insert({
+    email: `alice@example.com`,
+    favorite_color: `blue`,
+  });
+}
+```
+
 ### insert(...records)
 
 Inserts records into the database table. If you pass multiple records to `insert`, they will all be added "atomically", i.e. either all of the records will be added, or none of them will be added.

--- a/packages/pg-typed/src/__tests__/connections.test.pg.ts
+++ b/packages/pg-typed/src/__tests__/connections.test.pg.ts
@@ -1,0 +1,67 @@
+import connect, {sql} from '@databases/pg';
+import Schema from './__generated__';
+import tables from '..';
+
+const {users} = tables<Schema>({schemaName: 'typed_queries_connections'});
+
+const primary = connect({bigIntMode: 'number'});
+const secondary = connect({bigIntMode: 'number'});
+
+const User = users([primary, secondary]);
+
+afterAll(async () => {
+  await primary.dispose();
+  await secondary.dispose();
+});
+
+test('create schema', async () => {
+  await primary.query(sql`CREATE SCHEMA typed_queries_connections`);
+  await primary.query(
+    sql`
+      CREATE TABLE typed_queries_connections.users (
+        id BIGSERIAL NOT NULL PRIMARY KEY,
+        screen_name TEXT UNIQUE NOT NULL,
+        bio TEXT,
+        age INT
+      );
+    `,
+  );
+});
+
+test('create and find users', async () => {
+  const [forbes, ellie] = await User.insert(
+    {screen_name: 'Forbes'},
+    {screen_name: 'Ellie'},
+  );
+
+  const [forbes2, john] = await User.insertOrUpdate(
+    ['screen_name'],
+    {screen_name: 'Forbes', bio: 'Author of @databases'},
+    {screen_name: 'John', bio: 'Just a random name'},
+  );
+  expect(forbes2.id).toBe(forbes.id);
+  expect([forbes2.bio, john.bio]).toMatchInlineSnapshot(`
+    Array [
+      "Author of @databases",
+      "Just a random name",
+    ]
+  `);
+
+  const insertOrIgnoreResults = await User.insertOrIgnore(
+    {screen_name: 'John', bio: 'Updated bio'},
+    {screen_name: 'Martin', bio: 'Updated bio'},
+  );
+  expect(insertOrIgnoreResults.length).toBe(1);
+  const [martin] = insertOrIgnoreResults;
+  expect(martin.screen_name).toBe('Martin');
+  expect(martin.bio).toBe('Updated bio');
+
+  // We're closing the primary connection pool to verify that read queries are run from the second connection
+  await primary.dispose();
+
+  expect(await User.findOne({id: ellie.id})).toEqual(ellie);
+
+  expect(
+    (await User.find().orderByAsc('screen_name').first())?.screen_name,
+  ).toMatchInlineSnapshot(`"Ellie"`);
+});

--- a/packages/pg-typed/src/__tests__/index.test.pg.ts
+++ b/packages/pg-typed/src/__tests__/index.test.pg.ts
@@ -232,6 +232,6 @@ test('use a default connection', async () => {
   expect(() =>
     unconnectedUsers(undefined as any),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"You must either provide a \\"defaultConnection\\" to pg-typed, or specify a connection when accessing the table."`,
+    `"You must either provide a \\"defaultConnection\\" to pg-typed, or specify a list of connections when accessing the table."`,
   );
 });

--- a/packages/pg-typed/src/__tests__/index.test.pg.ts
+++ b/packages/pg-typed/src/__tests__/index.test.pg.ts
@@ -232,6 +232,6 @@ test('use a default connection', async () => {
   expect(() =>
     unconnectedUsers(undefined as any),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"You must either provide a \\"defaultConnection\\" to pg-typed, or specify a list of connections when accessing the table."`,
+    `"You must either provide a \\"defaultConnection\\" to pg-typed, or specify a connection when accessing the table."`,
   );
 });

--- a/packages/pg-typed/src/index.ts
+++ b/packages/pg-typed/src/index.ts
@@ -430,7 +430,7 @@ function getTable<TRecord, TInsertParameters>(
   ): Table<TRecord, TInsertParameters> => {
     if (!connections || (Array.isArray(connections) && !connections.length)) {
       throw new Error(
-        'You must either provide a "defaultConnection" to pg-typed, or specify a list of connections when accessing the table.',
+        'You must either provide a "defaultConnection" to pg-typed, or specify a connection when accessing the table.',
       );
     }
 


### PR DESCRIPTION
Closes #197

This PR adds support for primary/replicas query routing in `pg-typed`.

The unit test for this new feature is not using a primary+replica pg cluster, since it's more complex to setup in this testing environment, but I simulated having the primary connection closed while running read queries on the secondary connection.