### PR TITLE
feat: automatically handle "too many connections for role" error in pg

### DIFF
--- a/packages/connection-pool/src/utils/errors.ts
+++ b/packages/connection-pool/src/utils/errors.ts
@@ -40,3 +40,12 @@ export function attemptHook<TArgs extends any[]>(
     return ex as Error;
   }
 }
+
+export const connectionLimitExceeded = Symbol('CONNECTION_LIMIT_EXCEEDED');
+export type ConnectionLimitExceeded = typeof connectionLimitExceeded;
+
+export function isConnectionLimitExceeded<T>(
+  value: T | ConnectionLimitExceeded,
+): value is ConnectionLimitExceeded {
+  return value === connectionLimitExceeded;
+}

--- a/packages/pg/src/__tests__/too-many-connections-for-role.test.pg.ts
+++ b/packages/pg/src/__tests__/too-many-connections-for-role.test.pg.ts
@@ -1,0 +1,51 @@
+import connect, {sql, SQLErrorCode} from '..';
+
+jest.setTimeout(30_000);
+
+beforeAll(async () => {
+  const db = connect({
+    bigIntMode: 'bigint',
+  });
+  await db.query(sql`
+    CREATE SCHEMA too_many_connections;
+    CREATE ROLE too_many_connections WITH
+      LOGIN
+      PASSWORD 'test_password'
+      CONNECTION LIMIT 2;
+    CREATE TABLE too_many_connections.too_many_connections (
+      id INT NOT NULL PRIMARY KEY
+    );
+  `);
+  await db.dispose();
+});
+
+test(`Handling too many connections for role`, async () => {
+  const connectionString = `postgres://too_many_connections:test_password@${
+    process.env.PG_URL!.split(`@`)[1]
+  }`;
+  const errors: any[] = [];
+  const pool = connect({
+    bigIntMode: 'bigint',
+    connectionString,
+    onError(err) {
+      errors.push(err);
+    },
+  });
+  await Promise.all(
+    Array.from({length: 10}).map(async () => {
+      expect(
+        await pool.tx(async (db) => {
+          await new Promise<void>((r) => setTimeout(() => r(), 500));
+          return (await db.query(sql`SELECT 1+1 AS result`))[0].result;
+        }),
+      ).toBe(2);
+    }),
+  );
+  expect(errors.length).toBeGreaterThan(0);
+  expect(errors.length).toBeLessThan(10);
+  for (const err of errors) {
+    expect(err.message).toMatch(/too many connections for role/);
+    expect(err.code).toBe(SQLErrorCode.TOO_MANY_CONNECTIONS);
+  }
+  await pool.dispose();
+});


### PR DESCRIPTION
This automatically handles the error:

> too many connections for role "role_name"

from Postgres, providing we were able to create at least 1 connection for the pool. It will attempt to create connections again 5 seconds after encountering this error.