### PR TITLE
fix: stricter types for pg-typed's insert

### DIFF
--- a/packages/pg-typed/src/index.ts
+++ b/packages/pg-typed/src/index.ts
@@ -289,7 +289,7 @@ class Table<TRecord, TInsertParameters> {
     return results;
   }
 
-  insert<TRecordsToInsert extends readonly TInsertParameters[]>(
+  async insert<TRecordsToInsert extends readonly TInsertParameters[]>(
     ...rows: keyof TRecordsToInsert[number] extends keyof TInsertParameters
       ? TRecordsToInsert
       : readonly ({[key in keyof TInsertParameters]: TInsertParameters[key]} &

--- a/packages/pg-typed/src/index.ts
+++ b/packages/pg-typed/src/index.ts
@@ -289,16 +289,36 @@ class Table<TRecord, TInsertParameters> {
     return results;
   }
 
-  async insert<TRecordsToInsert extends readonly TInsertParameters[]>(
-    ...rows: TRecordsToInsert
-  ): Promise<{[key in keyof TRecordsToInsert]: TRecord}> {
+  insert<TRecordsToInsert extends readonly TInsertParameters[]>(
+    ...rows: keyof TRecordsToInsert[number] extends keyof TInsertParameters
+      ? TRecordsToInsert
+      : readonly ({[key in keyof TInsertParameters]: TInsertParameters[key]} &
+          {
+            [key in Exclude<
+              keyof TRecordsToInsert[number],
+              keyof TInsertParameters
+            >]: never;
+          })[]
+  ): Promise<
+    {
+      -readonly [key in keyof TRecordsToInsert]: TRecord;
+    }
+  > {
     return this._insert(null, ...rows) as any;
   }
 
   async insertOrUpdate<TRecordsToInsert extends readonly TInsertParameters[]>(
     conflictKeys: [keyof TRecord, ...(keyof TRecord)[]],
-    ...rows: TRecordsToInsert
-  ): Promise<{[key in keyof TRecordsToInsert]: TRecord}> {
+    ...rows: keyof TRecordsToInsert[number] extends keyof TInsertParameters
+      ? TRecordsToInsert
+      : readonly ({[key in keyof TInsertParameters]: TInsertParameters[key]} &
+          {
+            [key in Exclude<
+              keyof TRecordsToInsert[number],
+              keyof TInsertParameters
+            >]: never;
+          })[]
+  ): Promise<{-readonly [key in keyof TRecordsToInsert]: TRecord}> {
     const {sql} = this._underlyingDb;
     return this._insert(
       (columnNames) =>
@@ -316,7 +336,15 @@ class Table<TRecord, TInsertParameters> {
   }
 
   async insertOrIgnore<TRecordsToInsert extends readonly TInsertParameters[]>(
-    ...rows: TRecordsToInsert
+    ...rows: keyof TRecordsToInsert[number] extends keyof TInsertParameters
+      ? TRecordsToInsert
+      : readonly ({[key in keyof TInsertParameters]: TInsertParameters[key]} &
+          {
+            [key in Exclude<
+              keyof TRecordsToInsert[number],
+              keyof TInsertParameters
+            >]: never;
+          })[]
   ): Promise<TRecord[]> {
     const {sql} = this._underlyingDb;
     return await this._insert(() => sql`ON CONFLICT DO NOTHING`, ...rows);

--- a/tslint.json
+++ b/tslint.json
@@ -89,7 +89,7 @@
       true,
       "allow-fast-null-checks"
     ],
-    "no-use-before-declare": true,
+    "no-use-before-declare": false,
     "no-var-keyword": true,
     "no-void-expression": [
       true,
@@ -103,7 +103,7 @@
       "allow-null-check"
     ],
     "use-isnan": true,
-    "deprecation": true,
+    "deprecation": false,
     "no-duplicate-imports": true,
     "no-mergeable-namespace": true,
     "prefer-const": true,


### PR DESCRIPTION
This makes it harder to accidentally try to insert non-existant fields in pg-typed queries.