### PR TITLE
docs(mysql-test): set correct import paths for setup and teardown

### DIFF
--- a/docs/mysql-test.md
+++ b/docs/mysql-test.md
@@ -29,8 +29,8 @@ to take care of the rest.
 To setup jest, add the following keys to your jest config:
 
 ```json
-"globalSetup": "<rootDir>/node_modules/@databases/mysql-test/jest/globalSetup.js",
-"globalTeardown": "<rootDir>/node_modules/@databases/mysql-test/jest/globalTeardown.js",
+"globalSetup": "<rootDir>/node_modules/@databases/mysql-test/lib/jest/globalSetup.js",
+"globalTeardown": "<rootDir>/node_modules/@databases/mysql-test/lib/jest/globalTeardown.js",
 ```
 
 This will set up a MySQL server on a free port, before your tests run. It will tear down the MySQL server after all your tests run. N.B. Your tests will all share a single database, and execute in parallel, so you should not assume your generated IDs will have consistent values.

--- a/docs/mysql-test.md
+++ b/docs/mysql-test.md
@@ -29,8 +29,8 @@ to take care of the rest.
 To setup jest, add the following keys to your jest config:
 
 ```json
-"globalSetup": "<rootDir>/node_modules/@databases/mysql-test/lib/jest/globalSetup.js",
-"globalTeardown": "<rootDir>/node_modules/@databases/mysql-test/lib/jest/globalTeardown.js",
+"globalSetup": "<rootDir>/node_modules/@databases/mysql-test/jest/globalSetup",
+"globalTeardown": "<rootDir>/node_modules/@databases/mysql-test/jest/globalTeardown",
 ```
 
 This will set up a MySQL server on a free port, before your tests run. It will tear down the MySQL server after all your tests run. N.B. Your tests will all share a single database, and execute in parallel, so you should not assume your generated IDs will have consistent values.

--- a/docs/pg-test.md
+++ b/docs/pg-test.md
@@ -25,8 +25,8 @@ to take care of the rest.
 To setup jest, add the following keys to your jest config:
 
 ```json
-"globalSetup": "<rootDir>/node_modules/@databases/pg-test/jest/globalSetup.js",
-"globalTeardown": "<rootDir>/node_modules/@databases/pg-test/jest/globalTeardown.js",
+"globalSetup": "<rootDir>/node_modules/@databases/pg-test/jest/globalSetup",
+"globalTeardown": "<rootDir>/node_modules/@databases/pg-test/jest/globalTeardown",
 ```
 
 This will set up an in-memory postgres server on a free port, before your tests run. It will tear down the postrgres server after all your tests run. N.B. Your tests will all share a single database, and execute in parallel, so you should not assume your generated IDs will have consistent values.


### PR DESCRIPTION
Trying the other paths didn't work, these paths are what is indeed installed.