### PR TITLE
refactor: cleaner unnest usage

### DIFF
--- a/docs/blog/2022-01-21-optimizing-postgres-using-unnest.md
+++ b/docs/blog/2022-01-21-optimizing-postgres-using-unnest.md
@@ -28,9 +28,7 @@ You can run the following query:
 
 ```sql
 INSERT INTO users (email, favorite_color)
-SELECT
-  UNNEST(?::TEXT[]),
-  UNNEST(?::TEXT[])
+SELECT * FROM UNNEST(?::TEXT[], ?::TEXT[])
 ```
 
 With parameters like:
@@ -64,11 +62,10 @@ SET
   favorite_color=bulk_query.updated_favorite_color
 FROM
   (
-    SELECT
-      UNNEST(?::TEXT[])
-        AS email,
-      UNNEST(?::TEXT[])
-        AS updated_favorite_color
+    SELECT *
+    FROM
+      UNNEST(?::TEXT[], ?::TEXT[])
+      AS t(email, updated_favorite_color)
   ) AS bulk_query
 WHERE
   users.email=bulk_query.email
@@ -102,9 +99,8 @@ You can run the following query:
 ```sql
 SELECT * FROM users
 WHERE (email, favorite_color) IN (
-  SELECT
-    UNNEST(?::TEXT[]),
-    UNNEST(?::TEXT[])
+  SELECT *
+  FROM UNNEST(?::TEXT[], ?::TEXT[])
 )
 ```
 
@@ -134,11 +130,15 @@ An alternative if you need more control can be to use an INNER JOIN instead of t
 ```sql
 SELECT users.* FROM users
 INNER JOIN (
-  SELECT
-    UNNEST(?::TEXT[]) AS email,
-    UNNEST(?::TEXT[]) AS favorite_color
+  SELECT *
+  FROM
+    UNNEST(?::TEXT[], ?::TEXT[])
+    AS t(email, favorite_color)
 ) AS unnest_query
-ON (LOWER(users.email) = LOWER(unnest_query.email) AND LOWER(user.favorite_color) = LOWER(unnest_query.favorite_color))
+ON (
+  LOWER(users.email) = LOWER(unnest_query.email)
+  AND LOWER(users.favorite_color) = LOWER(unnest_query.favorite_color)
+)
 ```
 
 ## DELETE with thousands of different conditions in one go
@@ -150,9 +150,8 @@ You can run the following query:
 ```sql
 DELETE FROM users
 WHERE (email, favorite_color) IN (
-  SELECT
-    UNNEST(?::TEXT[]),
-    UNNEST(?::TEXT[])
+  SELECT *
+  FROM UNNEST(?::TEXT[], ?::TEXT[])
 )
 ```
 

--- a/docs/pg-bulk.md
+++ b/docs/pg-bulk.md
@@ -93,9 +93,11 @@ This is equivalent to:
 async function insertUsers(users) {
   await database.query(sql`
     INSERT INTO users (email, favorite_color)
-    SELECT
-      UNNEST(${users.map((u) => u.email)}::TEXT[]),
-      UNNEST(${users.map((u) => u.favorite_color)}::TEXT[])
+    SELECT * FROM
+      UNNEST(
+        ${users.map((u) => u.email)}::TEXT[],
+        ${users.map((u) => u.favorite_color)}::TEXT[]
+      )
   `);
 }
 ```
@@ -151,9 +153,11 @@ async function getUsers() {
   await database.query(sql`
     SELECT email, date_of_birth FROM users
     WHERE (email, favorite_color) IN (
-      SELECT
-        UNNEST(${['joe@example.com', 'ben@example.com']}::TEXT[]),
-        UNNEST(${['red', 'blue']}::TEXT[])
+      SELECT * FROM
+        UNNEST(
+          ${['joe@example.com', 'ben@example.com']}::TEXT[],
+          ${['red', 'blue']}::TEXT[]
+        )
     )
     ORDER BY email ASC
     LIMIT 100
@@ -211,11 +215,12 @@ async function updateFavoriteColors() {
       favorite_color=bulk_query.updated_value_of_favorite_color
     FROM
       (
-        SELECT
-          UNNEST(${['joe@example.com', 'ben@example.com']}::TEXT[])
-            AS email,
-          UNNEST(${['indigo', 'orange']}::TEXT[])
-            AS updated_value_of_favorite_color
+        SELECT * FROM
+          UNNEST(
+            ${['joe@example.com', 'ben@example.com']}::TEXT[],
+            ${['indigo', 'orange']}::TEXT[]
+          )
+          AS t(email, updated_value_of_favorite_color)
       ) AS bulk_query
     WHERE
       users.email=bulk_query.email
@@ -268,9 +273,11 @@ async function getUsers() {
   await database.query(sql`
     DELETE FROM users
     WHERE (email, favorite_color) IN (
-      SELECT
-        UNNEST(${['joe@example.com', 'ben@example.com']}::TEXT[]),
-        UNNEST(${['red', 'blue']}::TEXT[])
+      SELECT * FROM
+        UNNEST(
+          ${['joe@example.com', 'ben@example.com']}::TEXT[],
+          ${['red', 'blue']}::TEXT[]
+        )
     )
   `);
 }

--- a/packages/pg-bulk/src/__tests__/unnest-blog.test.pg.ts
+++ b/packages/pg-bulk/src/__tests__/unnest-blog.test.pg.ts
@@ -1,0 +1,163 @@
+import connect, {sql} from '@databases/pg';
+
+const SCHEMA_NAME = `unnest_blog_post`;
+const TABLE_NAME = `users`;
+const table = sql.ident(SCHEMA_NAME, TABLE_NAME);
+
+const db = connect({bigIntMode: 'number'});
+
+afterAll(async () => {
+  await db.dispose();
+});
+
+test('create schema', async () => {
+  await db.query(sql`CREATE SCHEMA ${sql.ident(SCHEMA_NAME)}`);
+  await db.query(sql`
+    CREATE TABLE ${table} (
+      email TEXT NOT NULL PRIMARY KEY,
+      favorite_color TEXT NOT NULL
+    );
+  `);
+});
+
+test('insert', async () => {
+  const p = [
+    ['joe@example.com', 'ben@example.com', 'mary@example.com'],
+    ['red', 'green', 'indigo'],
+  ];
+  await db.query(sql`
+    INSERT INTO ${table} (email, favorite_color)
+    SELECT * FROM UNNEST(${p[0]}::TEXT[], ${p[1]}::TEXT[])
+  `);
+  expect(await db.query(sql`SELECT * FROM ${table}`)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "email": "joe@example.com",
+        "favorite_color": "red",
+      },
+      Object {
+        "email": "ben@example.com",
+        "favorite_color": "green",
+      },
+      Object {
+        "email": "mary@example.com",
+        "favorite_color": "indigo",
+      },
+    ]
+  `);
+});
+
+test('update', async () => {
+  const p = [
+    ['joe@example.com', 'ben@example.com', 'mary@example.com'],
+    ['purple', 'violet', 'orange'],
+  ];
+  await db.query(sql`
+    UPDATE ${table}
+    SET
+      favorite_color=bulk_query.updated_favorite_color
+    FROM
+      (
+        SELECT *
+        FROM
+          UNNEST(${p[0]}::TEXT[], ${p[1]}::TEXT[])
+          AS t(email, updated_favorite_color)
+      ) AS bulk_query
+    WHERE
+      users.email=bulk_query.email
+  `);
+  expect(await db.query(sql`SELECT * FROM ${table}`)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "email": "joe@example.com",
+        "favorite_color": "purple",
+      },
+      Object {
+        "email": "ben@example.com",
+        "favorite_color": "violet",
+      },
+      Object {
+        "email": "mary@example.com",
+        "favorite_color": "orange",
+      },
+    ]
+  `);
+});
+
+test('select', async () => {
+  const p = [
+    ['joe@example.com', 'ben@example.com', 'mary@example.com'],
+    ['purple', 'violet', 'orange'],
+  ];
+  expect(
+    await db.query(sql`
+      SELECT * FROM ${table}
+      WHERE (email, favorite_color) IN (
+        SELECT *
+        FROM UNNEST(${p[0]}::TEXT[], ${p[1]}::TEXT[])
+      )
+    `),
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "email": "joe@example.com",
+        "favorite_color": "purple",
+      },
+      Object {
+        "email": "ben@example.com",
+        "favorite_color": "violet",
+      },
+      Object {
+        "email": "mary@example.com",
+        "favorite_color": "orange",
+      },
+    ]
+  `);
+  expect(
+    await db.query(sql`
+      SELECT users.* FROM ${table}
+      INNER JOIN (
+        SELECT *
+        FROM
+          UNNEST(${p[0]}::TEXT[], ${p[1]}::TEXT[])
+          AS t(email, favorite_color)
+      ) AS unnest_query
+      ON (
+        LOWER(users.email) = LOWER(unnest_query.email)
+        AND LOWER(users.favorite_color) = LOWER(unnest_query.favorite_color)
+      )
+    `),
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "email": "joe@example.com",
+        "favorite_color": "purple",
+      },
+      Object {
+        "email": "ben@example.com",
+        "favorite_color": "violet",
+      },
+      Object {
+        "email": "mary@example.com",
+        "favorite_color": "orange",
+      },
+    ]
+  `);
+});
+
+test('update', async () => {
+  const p = [
+    ['joe@example.com', 'ben@example.com', 'mary@example.com'],
+    ['purple', 'violet', 'orange'],
+  ];
+  await db.query(sql`
+    DELETE FROM ${table}
+    WHERE (email, favorite_color) IN (
+      SELECT *
+      FROM UNNEST(${p[0]}::TEXT[], ${p[1]}::TEXT[])
+    )
+  `);
+  expect(await db.query(sql`SELECT * FROM ${table}`)).toMatchInlineSnapshot(
+    `Array []`,
+  );
+});

--- a/packages/pg-bulk/src/__tests__/unnest-blog.test.pg.ts
+++ b/packages/pg-bulk/src/__tests__/unnest-blog.test.pg.ts
@@ -29,15 +29,16 @@ test('insert', async () => {
     INSERT INTO ${table} (email, favorite_color)
     SELECT * FROM UNNEST(${p[0]}::TEXT[], ${p[1]}::TEXT[])
   `);
-  expect(await db.query(sql`SELECT * FROM ${table}`)).toMatchInlineSnapshot(`
+  expect(await db.query(sql`SELECT * FROM ${table} ORDER BY email ASC`))
+    .toMatchInlineSnapshot(`
     Array [
-      Object {
-        "email": "joe@example.com",
-        "favorite_color": "red",
-      },
       Object {
         "email": "ben@example.com",
         "favorite_color": "green",
+      },
+      Object {
+        "email": "joe@example.com",
+        "favorite_color": "red",
       },
       Object {
         "email": "mary@example.com",
@@ -66,15 +67,16 @@ test('update', async () => {
     WHERE
       users.email=bulk_query.email
   `);
-  expect(await db.query(sql`SELECT * FROM ${table}`)).toMatchInlineSnapshot(`
+  expect(await db.query(sql`SELECT * FROM ${table} ORDER BY email ASC`))
+    .toMatchInlineSnapshot(`
     Array [
-      Object {
-        "email": "joe@example.com",
-        "favorite_color": "purple",
-      },
       Object {
         "email": "ben@example.com",
         "favorite_color": "violet",
+      },
+      Object {
+        "email": "joe@example.com",
+        "favorite_color": "purple",
       },
       Object {
         "email": "mary@example.com",
@@ -95,17 +97,17 @@ test('select', async () => {
       WHERE (email, favorite_color) IN (
         SELECT *
         FROM UNNEST(${p[0]}::TEXT[], ${p[1]}::TEXT[])
-      )
+      ) ORDER BY email ASC
     `),
   ).toMatchInlineSnapshot(`
     Array [
       Object {
-        "email": "joe@example.com",
-        "favorite_color": "purple",
-      },
-      Object {
         "email": "ben@example.com",
         "favorite_color": "violet",
+      },
+      Object {
+        "email": "joe@example.com",
+        "favorite_color": "purple",
       },
       Object {
         "email": "mary@example.com",
@@ -125,17 +127,17 @@ test('select', async () => {
       ON (
         LOWER(users.email) = LOWER(unnest_query.email)
         AND LOWER(users.favorite_color) = LOWER(unnest_query.favorite_color)
-      )
+      ) ORDER BY users.email ASC
     `),
   ).toMatchInlineSnapshot(`
     Array [
       Object {
-        "email": "joe@example.com",
-        "favorite_color": "purple",
-      },
-      Object {
         "email": "ben@example.com",
         "favorite_color": "violet",
+      },
+      Object {
+        "email": "joe@example.com",
+        "favorite_color": "purple",
       },
       Object {
         "email": "mary@example.com",
@@ -157,7 +159,7 @@ test('update', async () => {
       FROM UNNEST(${p[0]}::TEXT[], ${p[1]}::TEXT[])
     )
   `);
-  expect(await db.query(sql`SELECT * FROM ${table}`)).toMatchInlineSnapshot(
-    `Array []`,
-  );
+  expect(
+    await db.query(sql`SELECT * FROM ${table} ORDER BY email ASC`),
+  ).toMatchInlineSnapshot(`Array []`);
 });


### PR DESCRIPTION
You can use one `UNNEST` call with multiple arrays. This is the recommended way to produce records like this.

Thanks to [truilus on Reddit](https://www.reddit.com/r/PostgreSQL/comments/s9cw32/comment/htm2849/?utm_source=reddit&utm_medium=web2x&context=3) for the suggestion.