### PR TITLE
feat: allow using @databases/pg without a connection string

### DIFF
--- a/docs/pg-guide-connections.md
+++ b/docs/pg-guide-connections.md
@@ -80,3 +80,10 @@ process.once('SIGTERM', () => {
   });
 });
 ```
+
+## Connecting to/from cloud providers
+
+You can normally follow the instructions from the cloud providers, but we have prepared the following guides to make things easier for these common platforms:
+
+- [Google Cloud](pg-provider-google-cloud.md)
+- [Heroku](pg-provider-heroku.md)

--- a/docs/pg-options.md
+++ b/docs/pg-options.md
@@ -4,7 +4,7 @@ title: Postgres Connection Options
 sidebar_label: Connection Options
 ---
 
-- `connectionString` (`string | false`, default: `process.env.DATABASE_URL`) - Set this to `false` to disable all connection string & environment variable handling
+- `connectionString` (`string | false`, default: `process.env.DATABASE_URL`) - Set this to `false` to disable ignore the connection string even if there is one in the environment
 - `user` (`string`, default: from connection string or `process.env.PGUSER`)
 - `password` (`string`, default: from connection string or `process.env.PGPASSWORD`)
 - `host` (`string | string[]`, default: from connection string or `process.env.PGHOST`) - if multiple hosts are specified, we will attempt to connect to each one in turn until a successful connection is made.

--- a/docs/pg-provider-google-cloud.md
+++ b/docs/pg-provider-google-cloud.md
@@ -1,0 +1,69 @@
+---
+id: pg-provider-google-cloud
+title: Connecting to Postgres in Google Cloud
+sidebar_label: Google Cloud
+---
+
+This guide is for connecting to Cloud SQL Postgres instances in Google Cloud. If you're using a custom Postgres server or another cloud provider, refer to [Managing Postgres Connections](pg-guide-connections.md).
+
+## Connect from Cloud Run
+
+You may also find [the official google cloud docs](https://cloud.google.com/sql/docs/postgres/connect-run) helpful as those docs may be updated more frequently than this document. The official docs are not specific to `@database/pg` though.
+
+Before you can connect, you will need to:
+
+- Make sure that the instance created earlier has a public IP address. . You can verify this on the **Overview** page for your instance in the [Google Cloud Console](https://console.cloud.google.com/sql). If you need to add one, see the [Configuring public IP page](https://cloud.google.com/sql/docs/postgres/configure-ip) for instructions.
+- Get the `$INSTANCE_CONNECTION_NAME` for your instance. This can be found on the Overview page for your instance in the Google Cloud Console. or by running the following command: `gcloud sql instances describe $INSTANCE_NAME`.
+- Configure the service account for your service. Make sure that the service account has the appropriate Cloud SQL roles and permissions to connect to Cloud SQL. The service account for your service needs the `Cloud SQL Client` role.
+- Make sure you know the `$DB_USER`, `$DB_PASSWORD` and `$DB_NAME` name you want to connect to.
+
+The database password should be stored in [Google Secret Manager](https://cloud.google.com/secret-manager). Create a new secret to store the value of `$DB_PASSWORD` and note the `$DB_PASSWORD_SECRET_NAME`.
+
+To configure your cloud run service to connect to the Postgres database, run:
+
+```sh
+gcloud run services update $SERVICE_NAME \
+  --add-cloudsql-instances=$INSTANCE_CONNECTION_NAME \
+  --update-env-vars=PGHOST=/cloudsql/$INSTANCE_CONNECTION_NAME \
+  --update-env-vars=PGUSER=$DB_USER \
+  --update-secrets=PGPASSWORD=$DB_PASSWORD_SECRET_NAME:latest \
+  --update-env-vars=PGDATABASE=$DB_NAME
+```
+
+You can then connect using the following and @databases will automatically detect the config from your environment variables:
+
+```typescript
+import createConnectionPool from '@databases/pg';
+
+const db = createConnectionPool();
+```
+
+```javascript
+const createConnectionPool = require('@databases/pg');
+
+const db = createConnectionPool();
+```
+
+If you prefer to use custom environment variable names, you can also manually specify all the connection parameters:
+
+```typescript
+import createConnectionPool from '@databases/pg';
+
+const db = createConnectionPool({
+  user: process.env.DB_USER, // e.g. 'my-user'
+  password: process.env.DB_PASS, // e.g. 'my-user-password'
+  database: process.env.DB_NAME, // e.g. 'my-database'
+  host: `/cloudsql/${process.env.INSTANCE_CONNECTION_NAME}`,
+});
+```
+
+```javascript
+const createConnectionPool = require('@databases/pg');
+
+const db = createConnectionPool({
+  user: process.env.DB_USER, // e.g. 'my-user'
+  password: process.env.DB_PASS, // e.g. 'my-user-password'
+  database: process.env.DB_NAME, // e.g. 'my-database'
+  host: `/cloudsql/${process.env.INSTANCE_CONNECTION_NAME}`,
+});
+```

--- a/docs/pg-provider-heroku.md
+++ b/docs/pg-provider-heroku.md
@@ -1,0 +1,113 @@
+---
+id: pg-provider-heroku
+title: Connecting to Postgres in Heroku
+sidebar_label: Heroku
+---
+
+By default, if you attach a single Postgres database to a Heroku app, Heroku will automatically set `DATABASE_URL` to the connection string. This means you can simply do:
+
+```typescript
+import createConnectionPool from '@databases/pg';
+
+const db = createConnectionPool();
+```
+
+```javascript
+const createConnectionPool = require('@databases/pg');
+
+const db = createConnectionPool();
+```
+
+## Multiple Databases
+
+If you connect a second database to your app, Heroku will assign it a different environment variable. In this case you can specify the connection string manually using either:
+
+```typescript
+import createConnectionPool from '@databases/pg';
+
+const db = createConnectionPool(process.env.HEROKU_POSTGRESQL_ROSE);
+```
+
+```javascript
+const createConnectionPool = require('@databases/pg');
+
+const db = createConnectionPool(process.env.HEROKU_POSTGRESQL_ROSE);
+```
+
+or
+
+```typescript
+import createConnectionPool from '@databases/pg';
+
+const db = createConnectionPool({
+  connectionString: process.env.HEROKU_POSTGRESQL_ROSE,
+});
+```
+
+```javascript
+const createConnectionPool = require('@databases/pg');
+
+const db = createConnectionPool({
+  connectionString: process.env.HEROKU_POSTGRESQL_ROSE,
+});
+```
+
+## Connecting from your local machine
+
+Assuming you have [installed the Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli), and authenticated (by running `heroku login`) you can connect to your Heroku database for one off scripts and debugging from your local machine using:
+
+```typescript
+import {spawnSync} from 'child_process';
+import createConnectionPool from '@databases/pg';
+
+function getConnectionString(
+  herokuInstanceID: string,
+  environmentVariable: string = `DATABASE_URL`,
+) {
+  const result = spawnSync(
+    `heroku`,
+    [`config:get`, environmentVariable, `-a`, herokuInstanceID],
+    {
+      stdio: [`inherit`, `pipe`, `inherit`],
+      encoding: `utf8`,
+    },
+  );
+  if (result.status !== 0) {
+    process.stdout.write(result.stdout);
+    return process.exit(result.status);
+  }
+  return result.stdout.trim();
+}
+
+const db = createConnectionPool({
+  connectionString: getConnectionString(`my-app-name`),
+});
+```
+
+```javascript
+const {spawnSync} = require('child_process');
+const createConnectionPool = require('@databases/pg');
+
+function getConnectionString(
+  herokuInstanceID,
+  environmentVariable = `DATABASE_URL`,
+) {
+  const result = spawnSync(
+    `heroku`,
+    [`config:get`, environmentVariable, `-a`, herokuInstanceID],
+    {
+      stdio: [`inherit`, `pipe`, `inherit`],
+      encoding: `utf8`,
+    },
+  );
+  if (result.status !== 0) {
+    process.stdout.write(result.stdout);
+    return process.exit(result.status);
+  }
+  return result.stdout.trim();
+}
+
+const db = createConnectionPool({
+  connectionString: getConnectionString(`my-app-name`),
+});
+```

--- a/docs/sidebars.json
+++ b/docs/sidebars.json
@@ -32,6 +32,14 @@
           "pg-transaction",
           "pg-typed"
         ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Cloud Providers",
+        "ids": [
+          "pg-provider-google-cloud",
+          "pg-provider-heroku"
+        ]
       }
     ],
     "MySQL": [

--- a/packages/pg/src/index.ts
+++ b/packages/pg/src/index.ts
@@ -204,13 +204,6 @@ export default function createConnectionPool(
     connectionStringEnvironmentVariable
   ],
 ): ConnectionPool {
-  if (!connectionConfig) {
-    throw new Error(
-      'You must provide a connection string for @databases/pg. You can ' +
-        'either pass one directly to the createConnection call or set ' +
-        `the ${connectionStringEnvironmentVariable} environment variable.`,
-    );
-  }
   const {connectionString = process.env[connectionStringEnvironmentVariable]} =
     typeof connectionConfig === 'object'
       ? connectionConfig
@@ -271,6 +264,19 @@ export default function createConnectionPool(
     onConnectionOpened,
     onConnectionClosed,
   } = connectionConfigObject;
+
+  if (
+    !connectionConfig &&
+    ![user, password, host, database].some(
+      (v) => v !== undefined && !(Array.isArray(v) && v.length === 0),
+    )
+  ) {
+    throw new Error(
+      'You must provide a connection string for @databases/pg. You can ' +
+        'either pass one directly to the createConnection call or set ' +
+        `the ${connectionStringEnvironmentVariable} environment variable.`,
+    );
+  }
 
   if (bigIntAsString) {
     console.warn(

--- a/packages/website/components/Document.tsx
+++ b/packages/website/components/Document.tsx
@@ -2,7 +2,7 @@ import 'twin.macro';
 import type * as m from 'mdast';
 import tw from 'twin.macro';
 import {createContext, memo, useContext} from 'react';
-import {CodeBlock, CodeTokenType} from './CodeBlock';
+import {CodeBlock, CodeTokenType, EnvironmentEditor} from './CodeBlock';
 
 const HeadingContext = createContext(false);
 function useIsInHeading() {
@@ -226,6 +226,21 @@ function DocumentInlineCode({node}: {node: m.InlineCode}) {
       <span tw="p-1 -my-1 rounded-sm bg-yellow-200">
         {node.value.substring(`@[[[`.length, node.value.length - `]]]@`.length)}
       </span>
+    );
+  }
+  if (/^\$[A-Z_]+$/.test(node.value)) {
+    return (
+      <code
+        tw="font-mono p-1 -my-1 rounded-sm"
+        css={[
+          !isInBlockquote && tw`bg-gray-100`,
+          isInBlockquote && tw`bg-yellow-100`,
+        ]}
+      >
+        <span tw="text-red-500">
+          <EnvironmentEditor name={node.value} />
+        </span>
+      </code>
     );
   }
   return (

--- a/packages/website/pages/_app.tsx
+++ b/packages/website/pages/_app.tsx
@@ -3,6 +3,7 @@ import {GlobalStyles} from 'twin.macro';
 import {useRouter} from 'next/router';
 import {useEffect} from 'react';
 import {pageView} from '../utils/gtag';
+import {EnvironmentProvider} from '../components/CodeBlock';
 
 function MyApp({Component, pageProps}: any) {
   const router = useRouter();
@@ -19,7 +20,10 @@ function MyApp({Component, pageProps}: any) {
   return (
     <>
       <GlobalStyles />
-      <Component {...pageProps} />
+
+      <EnvironmentProvider>
+        <Component {...pageProps} />
+      </EnvironmentProvider>
     </>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2561,9 +2561,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001251, caniuse-lite@^1.0.30001252:
-  version "1.0.30001252"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz#cb16e4e3dafe948fc4a9bb3307aea054b912019a"
-  integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
+  version "1.0.30001309"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz"
+  integrity sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This lets you use `$PGHOST`, `$PGUSER` etc. to configure your connection, which can work better in environments that expect you to connect using a unix socket and/or if you want to store only your database password in a secret manager.