### PR TITLE
Add schema param to mssql/pg-schema-cli

### DIFF
--- a/packages/mysql-schema-cli/src/index.ts
+++ b/packages/mysql-schema-cli/src/index.ts
@@ -10,7 +10,8 @@ import {writeSchema} from '@databases/mysql-schema-print-types';
 const parameterParser = startChain()
   .addParam(param.string(['-c', '--database'], 'database'))
   .addParam(param.string(['-d', '--directory'], 'directory'))
-  .addParam(param.string(['--config'], 'configFilename'));
+  .addParam(param.string(['--config'], 'configFilename'))
+  .addParam(param.string(['-s', '--schemaName'], 'schemaName'));
 export default async function run(
   cwd: string,
   args: string[],
@@ -48,7 +49,7 @@ export default async function run(
   const connection = connect({connectionString: database, poolSize: 1});
   let schema;
   try {
-    schema = await getSchema(connection);
+    schema = await getSchema(connection, {schemaName: params.schemaName});
   } finally {
     await connection.dispose().catch(() => {
       // ignore the error if it's just disposing the database connection

--- a/packages/pg-schema-cli/src/index.ts
+++ b/packages/pg-schema-cli/src/index.ts
@@ -10,7 +10,8 @@ import {writeSchema} from '@databases/pg-schema-print-types';
 const parameterParser = startChain()
   .addParam(param.string(['-c', '--database'], 'database'))
   .addParam(param.string(['-d', '--directory'], 'directory'))
-  .addParam(param.string(['--config'], 'configFilename'));
+  .addParam(param.string(['--config'], 'configFilename'))
+  .addParam(param.string(['-s', '--schemaName'], 'schemaName'));
 export default async function run(
   cwd: string,
   args: string[],
@@ -48,7 +49,7 @@ export default async function run(
   const connection = connect({connectionString: database, poolSize: 1});
   let schema;
   try {
-    schema = await getSchema(connection);
+    schema = await getSchema(connection, {schemaName: params.schemaName});
   } finally {
     await connection.dispose().catch(() => {
       // ignore the error if it's just disposing the database connection


### PR DESCRIPTION
Found through personal use that there wasn't a built-in way to specify the schema to the `pg-schema-cli` package, but that the `getSchema` function it uses has that functionality, so I thought I'd put together the lego blocks, so to speak.

Later noticed the same deal was true of `mssql-schema-cli`, so took the liberty of doing that, too.