### PR TITLE
Always run container in amd64 platform

### DIFF
--- a/packages/with-container/src/index.ts
+++ b/packages/with-container/src/index.ts
@@ -91,6 +91,8 @@ export function startDockerContainer(options: NormalizedOptions) {
     'docker',
     [
       'run',
+      '--platform',
+      'linux/amd64',
       '--name',
       options.containerName,
       '-t', // terminate when sent SIGTERM


### PR DESCRIPTION
To support m1 devices for example https://github.com/ForbesLindesay/atdatabases/issues/214