### PR TITLE
LimitOffset implementation

### DIFF
--- a/docs/mysql-typed.md
+++ b/docs/mysql-typed.md
@@ -253,6 +253,27 @@ export async function printAllEmails() {
 }
 ```
 
+### limitOffset(count, offset)
+
+Return the first `count` rows offset by `offset` number of rows.  N.B. you can only use this method if you have first called `orderByAsc` or `orderByDesc` at least once.
+
+If you have a large number of rows (more than some thousands), using an offset is inefficient as it will scan through the results. For larger sets, see the endless pagination example above.
+
+```typescript
+import db, {users} from './database';
+
+// Example for simple offset-based pagination
+export async function offsetPaginatedEmails(offset?: number = 0) {
+  const records = await users(db)
+    .find()
+    .orderByAsc(`email`)
+    .limitOffset(10, offset);
+  return {
+    records: records.map((record) => record.email),
+  };
+}
+```
+
 ### first()
 
 Return the first record. If there are no records, `null` is returned. N.B. you can only use this method if you have first called `orderByAsc` or `orderByDesc` at least once.

--- a/docs/pg-typed.md
+++ b/docs/pg-typed.md
@@ -484,7 +484,8 @@ Return the first `count` rows. N.B. you can only use this method if you have fir
 ```typescript
 import db, {users} from './database';
 
-export async function paginatedEmails(nextPageToken?: string) {
+// Example for an endless pagination. Expects an email to be passed in, from where it returns 10 more rows.
+export async function endlessPaginatedEmails(nextPageToken?: string) {
   const records = await users(db)
     .find({
       ...(nextPageToken ? {email: gt(nextPageToken)} : {}),
@@ -498,7 +499,7 @@ export async function paginatedEmails(nextPageToken?: string) {
 }
 
 export async function printAllEmails() {
-  let page = await paginatedEmails();
+  let page = await endlessPaginatedEmails();
   while (page.records.length) {
     for (const email of page.records) {
       console.log(email);
@@ -506,8 +507,29 @@ export async function printAllEmails() {
     if (!page.nextPageToken) {
       break;
     }
-    page = await paginatedEmails(page.nextPageToken);
+    page = await endlessPaginatedEmails(page.nextPageToken);
   }
+}
+```
+
+### limitOffset(count, offset)
+
+Return the first `count` rows offset by `offset` number of rows.  N.B. you can only use this method if you have first called `orderByAsc` or `orderByDesc` at least once.
+
+If you have a large number of rows (more than some thousands), using an offset is inefficient as it will scan through the results. For larger sets, see the endless pagination example above.
+
+```typescript
+import db, {users} from './database';
+
+// Example for simple offset-based pagination
+export async function offsetPaginatedEmails(offset?: number = 0) {
+  const records = await users(db)
+    .find()
+    .orderByAsc(`email`)
+    .limitOffset(10, offset);
+  return {
+    records: records.map((record) => record.email),
+  };
 }
 ```
 

--- a/packages/mock-db-typed/src/index.ts
+++ b/packages/mock-db-typed/src/index.ts
@@ -1,4 +1,4 @@
-import type {sql, SQLQuery, Queryable} from '@databases/mock-db';
+import type {Queryable, SQLQuery, sql} from '@databases/mock-db';
 
 export interface SelectQuery<TRecord> {
   all(): Promise<TRecord[]>;
@@ -14,6 +14,7 @@ export interface SelectQuery<TRecord> {
 export interface OrderedSelectQuery<TRecord> extends SelectQuery<TRecord> {
   first(): Promise<TRecord | null>;
   limit(count: number): Promise<TRecord[]>;
+  limitOffset(count: number, offset: number): Promise<TRecord[]>;
 }
 
 class FieldQuery<T> {
@@ -134,6 +135,7 @@ class SelectQueryImplementation<TRecord>
 {
   public readonly orderByQueries: SQLQuery[] = [];
   public limitCount: number | undefined;
+  public offsetCount: number | undefined;
   private _selectFields: SQLQuery | undefined;
 
   constructor(
@@ -163,6 +165,9 @@ class SelectQueryImplementation<TRecord>
     }
     if (this.limitCount) {
       parts.push(sql`LIMIT ${this.limitCount}`);
+    }
+    if(this.offsetCount) {
+      parts.push(sql`OFFSET ${this.offsetCount}`);
     }
     return this._executeQuery(
       parts.length === 1 ? parts[0] : sql.join(parts, sql` `),
@@ -204,6 +209,16 @@ class SelectQueryImplementation<TRecord>
     }
     this.limitCount = count;
     return await this._getResults('limit');
+  }
+  public async limitOffset(count: number, offset: number) {
+    if (!this.orderByQueries.length) {
+      throw new Error(
+        'You cannot call "limitOffset" until after you call "orderByAsc" or "orderByDesc".',
+      );
+    }
+    this.limitCount = limit;
+    this.offsetCount = offset;
+    return await this._getResults('limitOffset');
   }
   public async first() {
     if (!this.orderByQueries.length) {

--- a/packages/mysql-typed/src/__tests__/index.test.mysql.ts
+++ b/packages/mysql-typed/src/__tests__/index.test.mysql.ts
@@ -1,4 +1,5 @@
 import connect, {sql} from '@databases/mysql';
+
 import declareTables from '..';
 
 // JSON added in 5.7
@@ -114,6 +115,18 @@ t('create users', async () => {
       "http://example.com/2",
     ]
   `);
+
+  const photoRecordsOffset = await photos(db)
+    .find({owner_user_id: 1})
+    .orderByAsc('cdn_url')
+    .limitOffset(2, 1);
+  expect(photoRecordsOffset.map((p) => p.cdn_url)).toMatchInlineSnapshot(`
+    Array [
+      "http://example.com/2",
+      "http://example.com/3",
+    ]
+  `);
+
 
   const photoRecordsDesc = await photos(db)
     .find({owner_user_id: 1})

--- a/packages/mysql-typed/src/index.ts
+++ b/packages/mysql-typed/src/index.ts
@@ -1,4 +1,4 @@
-import {sql, SQLQuery, Queryable} from '@databases/mysql';
+import {Queryable, SQLQuery, sql} from '@databases/mysql';
 
 export interface SelectQuery<TRecord> {
   all(): Promise<TRecord[]>;
@@ -14,6 +14,7 @@ export interface SelectQuery<TRecord> {
 export interface OrderedSelectQuery<TRecord> extends SelectQuery<TRecord> {
   first(): Promise<TRecord | null>;
   limit(count: number): Promise<TRecord[]>;
+  limitOffset(count: number, offset: number): Promise<TRecord[]>;
 }
 
 class FieldQuery<T> {
@@ -134,6 +135,7 @@ class SelectQueryImplementation<TRecord>
 {
   public readonly orderByQueries: SQLQuery[] = [];
   public limitCount: number | undefined;
+  public offsetCount: number | undefined;
   private _selectFields: SQLQuery | undefined;
 
   constructor(
@@ -163,6 +165,9 @@ class SelectQueryImplementation<TRecord>
     }
     if (this.limitCount) {
       parts.push(sql`LIMIT ${this.limitCount}`);
+    }
+    if(this.offsetCount) {
+      parts.push(sql`OFFSET ${this.offsetCount}`);
     }
     return this._executeQuery(
       parts.length === 1 ? parts[0] : sql.join(parts, sql` `),
@@ -204,6 +209,16 @@ class SelectQueryImplementation<TRecord>
     }
     this.limitCount = count;
     return await this._getResults('limit');
+  }
+  public async limitOffset(count: number, offset: number) {
+    if (!this.orderByQueries.length) {
+      throw new Error(
+        'You cannot call "limitOffset" until after you call "orderByAsc" or "orderByDesc".',
+      );
+    }
+    this.limitCount = limit;
+    this.offsetCount = offset;
+    return await this._getResults('limitOffset');
   }
   public async first() {
     if (!this.orderByQueries.length) {

--- a/packages/pg-typed/src/__tests__/index.test.pg.ts
+++ b/packages/pg-typed/src/__tests__/index.test.pg.ts
@@ -1,4 +1,5 @@
 import connect, {pgFormat, sql} from '@databases/pg';
+
 import Schema from './__generated__';
 import defineTables from '..';
 
@@ -85,6 +86,16 @@ test('create users', async () => {
     Array [
       "http://example.com/1",
       "http://example.com/2",
+    ]
+  `);
+  const photoRecordsOffset = await photos(db)
+    .find({owner_user_id: forbes.id})
+    .orderByAsc('cdn_url')
+    .limitOffset(2, 1);
+  expect(photoRecordsOffset.map((p) => p.cdn_url)).toMatchInlineSnapshot(`
+    Array [
+      "http://example.com/2",
+      "http://example.com/3",
     ]
   `);
 


### PR DESCRIPTION
To address #234

I've added a skeleton for a `limitOffset` next to `limit` that would pass in an offset value for `pg-typed` and `mysql-typed`. 

This probably still needs some work but I just wanted to ask if you're open for such a feature.