### PR TITLE
complementary fix, pull docker image as amd64 as well

### DIFF
--- a/packages/with-container/src/index.ts
+++ b/packages/with-container/src/index.ts
@@ -75,7 +75,7 @@ export async function pullDockerImage(options: NormalizedOptions | Options) {
     return;
   }
   console.warn('Pulling Docker Image ' + options.image);
-  await spawnBuffered('docker', ['pull', options.image], {
+  await spawnBuffered('docker', ['pull', '--platform', 'linux/amd64', options.image], {
     debug: options.debug,
   }).getResult();
 }


### PR DESCRIPTION
This is complementary to https://github.com/ForbesLindesay/atdatabases/pull/248

I have not tested that solution in isolate, and have already pulled the image myself (`docker pull mysql:8.0.23 --platform linux/amd64`) and so did not encounter an error when pulling.

I will note however, that `npx mysql-test start` errors when the "Temporary server" is stopped:

> mysql:8.0.23 already pulled (use mysql-test start --refresh or ops.refreshImage to refresh)
Starting Docker Container mysql-test
Waiting for mysql-test on port 3306...
Waiting for mysql-test on port 3306...
Error: Connection lost: The server closed the connection.


```
2022-08-04 12:56:43+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.23-1debian10 started.

2022-08-04 12:56:43+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'

2022-08-04 12:56:43+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.23-1debian10 started.

2022-08-04 12:56:44+00:00 [Note] [Entrypoint]: Initializing database files

2022-08-04T12:56:44.463778Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.23) initializing of server in progress as process 100

2022-08-04T12:56:44.540074Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.

2022-08-04T12:56:44.565752Z 1 [ERROR] [MY-012585] [InnoDB] Linux Native AIO interface is not supported on this platform. Please check your OS documentation and install appropriate binary of InnoDB.

2022-08-04T12:56:44.566475Z 1 [Warning] [MY-012654] [InnoDB] Linux Native AIO disabled.

2022-08-04T12:56:45.348819Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.

2022-08-04T12:56:49.065615Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.

2022-08-04 12:56:54+00:00 [Note] [Entrypoint]: Database files initialized

2022-08-04 12:56:54+00:00 [Note] [Entrypoint]: Starting temporary server

mysqld will log errors to /var/lib/mysql/4ec9cc34e37b.err

mysqld is running as pid 156

2022-08-04 12:56:56+00:00 [Note] [Entrypoint]: Temporary server started.

Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.

Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.

Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.

Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.

2022-08-04 12:57:06+00:00 [Note] [Entrypoint]: Creating database test-db

2022-08-04 12:57:06+00:00 [Note] [Entrypoint]: Creating user test-user

2022-08-04 12:57:06+00:00 [Note] [Entrypoint]: Giving user test-user access to schema test-db


2022-08-04 12:57:06+00:00 [Note] [Entrypoint]: Stopping temporary server

2022-08-04 12:57:07+00:00 [Note] [Entrypoint]: Temporary server stopped


2022-08-04 12:57:07+00:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.


2022-08-04T12:57:08.173666Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.23) starting as process 1

2022-08-04T12:57:08.263844Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.

2022-08-04T12:57:08.295218Z 1 [ERROR] [MY-012585] [InnoDB] Linux Native AIO interface is not supported on this platform. Please check your OS documentation and install appropriate binary of InnoDB.

2022-08-04T12:57:08.296013Z 1 [Warning] [MY-012654] [InnoDB] Linux Native AIO disabled.

2022-08-04T12:57:08.594534Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.

2022-08-04T12:57:09.127410Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock

2022-08-04T12:57:09.385057Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.

2022-08-04T12:57:09.386661Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.

2022-08-04T12:57:09.399057Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.

2022-08-04T12:57:09.511710Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.23'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
```