### PR TITLE
Fix incorrect transaction revert keyword

### DIFF
--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -137,7 +137,7 @@ class DatabaseConnectionImplementation implements DatabaseConnection {
         return result;
       } catch (ex) {
         await new Promise<void>((resolve, reject) => {
-          this._database.run('REVERT', (err) => {
+          this._database.run('ROLLBACK', (err) => {
             if (err) reject(err);
             else resolve();
           });


### PR DESCRIPTION
Test:
```
sqlite> BEGIN;
sqlite> CREATE TABLE foo (a, b);
sqlite> ROLLBACK;

sqlite> BEGIN;
sqlite> CREATE TABLE foo (a, b);
sqlite> REVERT;
Error: near "REVERT": syntax error
```

ROLLBACK is the correct keyword -- https://www.sqlite.org/lang_transaction.html