### PR TITLE
[DOCS]: Fix `allOf` field query section

### DIFF
--- a/docs/pg-typed.md
+++ b/docs/pg-typed.md
@@ -570,12 +570,12 @@ You can use `isNoResultFoundError` to test a caught exception to see if it is th
 
 ## FieldQuery
 
-### anyOf(valuesOrFieldQueries)
+### allOf(valuesOrFieldQueries)
 
 Match all of the supplied values. For example, to get posts within a time range:
 
 ```typescript
-import {anyOf} from '@databases/pg-typed';
+import {allOf, anyOf} from '@databases/pg-typed';
 import db, {posts} from './database';
 
 /**


### PR DESCRIPTION
Ensure `allOf` section has a header referencing the correct field query (was previously referencing `anyOf`) and ensure it imports `allOf` from `@databases/pg-typed`