### PR TITLE
Missing await on transaction in sqlite breaks rollback

### DIFF
--- a/packages/sqlite/src/__tests__/index.test.ts
+++ b/packages/sqlite/src/__tests__/index.test.ts
@@ -79,8 +79,8 @@ test('transaction with rollback', async () => {
       expect(result).toEqual([{id: 1}, {id: 2}, {id: 42}]);
       throw new Error('rollback');
     });
-  } catch (e) {
-    // rollback
+  } catch (e: any) {
+    expect(e.message).toBe('rollback');
   }
   const result = await db.query(sql`SELECT id from test_rollback;`);
   expect(result).toEqual([]);

--- a/packages/sqlite/src/index.ts
+++ b/packages/sqlite/src/index.ts
@@ -125,7 +125,7 @@ class DatabaseConnectionImplementation implements DatabaseConnection {
         });
       });
       try {
-        const result = fn(
+        const result = await fn(
           new DatabaseTransactionImplementation(this._database),
         );
         await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Here there should be an `await` https://github.com/ForbesLindesay/atdatabases/blob/master/packages/sqlite/src/index.ts#L128
Without it, `result` is a unresolved `Promise`, so the `COMMIT` is always executed. 
Added a small test to be sure that the rollback is done if `fn` throws. 