### PR TITLE
fix documentation of @databases/mysql-schema-cli with --schemaName param

### DIFF
--- a/docs/mysql-guide-typescript.md
+++ b/docs/mysql-guide-typescript.md
@@ -32,7 +32,7 @@ To generate the types, you will need your database connection string from [Insta
 You can then generate types by running:
 
 ```npm
-npx @databases/mysql-schema-cli --database mysql://test-user:password@localhost:3306/test-db --directory src/__generated__
+npx @databases/mysql-schema-cli --database mysql://test-user:password@localhost:3306/ --schemaName test-db --directory src/__generated__
 ```
 
 You will need to replace the connection string in this example with your actual connection string.

--- a/docs/mysql-guide-typescript.md
+++ b/docs/mysql-guide-typescript.md
@@ -32,7 +32,10 @@ To generate the types, you will need your database connection string from [Insta
 You can then generate types by running:
 
 ```npm
-npx @databases/mysql-schema-cli --database mysql://test-user:password@localhost:3306/ --schemaName test-db --directory src/__generated__
+npx @databases/mysql-schema-cli \
+  --database mysql://test-user:password@localhost:3306/ \
+  --schemaName test-db \
+  --directory src/__generated__
 ```
 
 You will need to replace the connection string in this example with your actual connection string.


### PR DESCRIPTION
## Problem
Looks like by default, following the docs, @databases/mysql-schema-cli accesses all databases a user has and generates too much files/types, not taking into account specified schema name. Looks like there is a dedicated, not documented `schemaName` param now used for that..

![Screenshot_20221213_164155](https://user-images.githubusercontent.com/445122/207363498-d8336efe-821c-4e59-b0d5-646727b2e093.png)


## Changes
update docs to use `--schemaName` param

### Before
![Screenshot_20221213_163136](https://user-images.githubusercontent.com/445122/207360761-ec99f478-306d-4048-8457-ae0d027c2fbb.png)

### After
![Screenshot_20221213_163230](https://user-images.githubusercontent.com/445122/207360971-3cff290e-a6f5-4a05-af73-1980b53849b6.png)
