### PR TITLE
Use server_version setting to resolve current PG version.

### DIFF
--- a/packages/pg-migrations/src/PostgresDatabaseEngine.ts
+++ b/packages/pg-migrations/src/PostgresDatabaseEngine.ts
@@ -248,14 +248,13 @@ function getExport(mod: any, filename: string) {
 }
 
 async function getPgVersion(connection: Queryable): Promise<[number, number]> {
-  // e.g. PostgreSQL 10.1 on x86_64-apple-darwin16.7.0, compiled by Apple LLVM version 9.0.0 (clang-900.0.38), 64-bit
-  const [{version: sqlVersionString}] = await connection.query(
-    connection.sql`SELECT version();`,
+  // server_version -> 10.6.0
+  const [{server_version: sqlVersionString}] = await connection.query(
+    connection.sql`SHOW server_version;`,
   );
-  const match = /PostgreSQL (\d+).(\d+)/.exec(sqlVersionString);
-  if (match) {
-    const [, major, minor] = match;
-    return [parseInt(major, 10), parseInt(minor, 10)];
+  const versions = sqlVersionString.split('.');
+  if (versions.length > 1) {
+    return [parseInt(versions[0], 10), parseInt(versions[1], 10)];
   }
   return [0, 0];
 }

--- a/packages/pg-schema-introspect/src/__tests__/getTypes.test.pg.ts
+++ b/packages/pg-schema-introspect/src/__tests__/getTypes.test.pg.ts
@@ -519,14 +519,13 @@ test('get custom types', async () => {
 });
 
 async function getPgVersion(): Promise<[number, number]> {
-  // e.g. PostgreSQL 10.1 on x86_64-apple-darwin16.7.0, compiled by Apple LLVM version 9.0.0 (clang-900.0.38), 64-bit
-  const [{version: sqlVersionString}] = await db.query(
-    db.sql`SELECT version();`,
+  // server_version -> 10.6.0
+  const [{server_version: sqlVersionString}] = await db.query(
+    db.sql`SHOW server_version;`,
   );
-  const match = /PostgreSQL (\d+).(\d+)/.exec(sqlVersionString);
-  if (match) {
-    const [, major, minor] = match;
-    return [parseInt(major, 10), parseInt(minor, 10)];
+  const versions = sqlVersionString.split('.');
+  if (versions.length > 1) {
+    return [parseInt(versions[0], 10), parseInt(versions[1], 10)];
   }
   return [0, 0];
 }


### PR DESCRIPTION
Fixes #278

## Notes

During development I've encountered a flaky test for `pg-migrations` module - it looks like running tests in parallel can cause some of migration tests to fail. In particular on my local environment I can reproduce failures of dry-run test after applying migrations when running full test suite:
```shell 
yarn test --verbose
```

Failing test:
<img width="981" alt="Screenshot 2023-01-21 at 14 05 12" src="https://user-images.githubusercontent.com/38127655/213868148-39e1861a-8365-4032-be81-c37ed583c0e3.png">

I think I narrowed down the root cause to [getSearchPath](https://github.com/ForbesLindesay/atdatabases/blob/8af7cdc8711a86998523e9a62594b612ba9e0f4b/packages/pg-schema-introspect/src/__tests__/getSearchPath.test.pg.ts#L19) test - it creates new schema which is going to be included into default PG search path (since it matches PG user name), so if schema is created between two migration tests it might appear as migration hasn't been applied since it previously was using different schema (public).

I didn't address this issue but this is something you might want to keep in mind.