### PR TITLE
Fix: Generic Type Support in 'Queryable.query'

### DIFF
--- a/packages/pg-bulk/src/__tests__/index.test.pg.ts
+++ b/packages/pg-bulk/src/__tests__/index.test.pg.ts
@@ -109,7 +109,7 @@ test('create users in bulk', async () => {
       values: ['Array<string>', 'Array<number>', 'Array<string>'],
     },
   ]);
-  const records = await db.query(
+  const records = await db.query<{screen_name: string; age: number}>(
     sql`SELECT screen_name, age FROM ${table} ORDER BY screen_name ASC`,
   );
   expect(records.map((i) => i.screen_name)).toEqual(names.sort());

--- a/packages/pg-migrations/src/PostgresDatabaseEngine.ts
+++ b/packages/pg-migrations/src/PostgresDatabaseEngine.ts
@@ -97,7 +97,7 @@ export default class PostgresDatabaseEngine
     return await this._connection.tx(async (tx) => {
       return await fn({
         async getVersion(): Promise<string> {
-          const versionRecords = await tx.query(
+          const versionRecords = await tx.query<{version: string}>(
             tx.sql`SELECT version FROM ${versionTableName} WHERE id=0`,
           );
           if (versionRecords.length) {
@@ -129,7 +129,7 @@ export default class PostgresDatabaseEngine
               );
             `);
           }
-          const updatedRecords = await tx.query(tx.sql`
+          const updatedRecords = await tx.query<{id: number}>(tx.sql`
             UPDATE ${versionTableName} SET version=${newVersion}
             RETURNING id
           `);
@@ -249,7 +249,7 @@ function getExport(mod: any, filename: string) {
 
 async function getPgVersion(connection: Queryable): Promise<[number, number]> {
   // e.g. PostgreSQL 10.1 on x86_64-apple-darwin16.7.0, compiled by Apple LLVM version 9.0.0 (clang-900.0.38), 64-bit
-  const [{version: sqlVersionString}] = await connection.query(
+  const [{version: sqlVersionString}] = await connection.query<{version: any}>(
     connection.sql`SELECT version();`,
   );
   const match = /PostgreSQL (\d+).(\d+)/.exec(sqlVersionString);

--- a/packages/pg-schema-introspect/src/__tests__/getTypes.test.pg.ts
+++ b/packages/pg-schema-introspect/src/__tests__/getTypes.test.pg.ts
@@ -520,7 +520,7 @@ test('get custom types', async () => {
 
 async function getPgVersion(): Promise<[number, number]> {
   // e.g. PostgreSQL 10.1 on x86_64-apple-darwin16.7.0, compiled by Apple LLVM version 9.0.0 (clang-900.0.38), 64-bit
-  const [{version: sqlVersionString}] = await db.query(
+  const [{version: sqlVersionString}] = await db.query<{version: any}>(
     db.sql`SELECT version();`,
   );
   const match = /PostgreSQL (\d+).(\d+)/.exec(sqlVersionString);

--- a/packages/pg-schema-introspect/src/getClasses.ts
+++ b/packages/pg-schema-introspect/src/getClasses.ts
@@ -22,7 +22,7 @@ export default async function getClasses(
 ): Promise<Class[]> {
   const conditions = classQuery(query);
 
-  const tables = await connection.query(sql`
+  const tables = await connection.query<Class>(sql`
     SELECT
       ns.oid as "schemaID",
       ns.nspname as "schemaName",

--- a/packages/pg-schema-introspect/src/getConstraints.ts
+++ b/packages/pg-schema-introspect/src/getConstraints.ts
@@ -37,7 +37,7 @@ export default async function getConstraints(
 ): Promise<Constraint[]> {
   const conditions = classQuery(query);
 
-  const constraints = await connection.query(sql`
+  const constraints = await connection.query<Constraint>(sql`
     SELECT
       conname AS "constraintName",
       contype AS "constraintType",

--- a/packages/pg-schema-introspect/src/getEnumValues.ts
+++ b/packages/pg-schema-introspect/src/getEnumValues.ts
@@ -14,7 +14,7 @@ export default async function getEnumValues(
 ): Promise<EnumValue[]> {
   const conditions = typeQuery(query);
 
-  const enumValues = await connection.query(sql`
+  const enumValues = await connection.query<EnumValue>(sql`
     SELECT
       ns.oid AS "schemaID",
       ns.nspname AS "schemaName",

--- a/packages/pg-typed/src/index.ts
+++ b/packages/pg-typed/src/index.ts
@@ -1022,7 +1022,7 @@ class Table<TRecord, TInsertParameters> {
         )})`,
     );
 
-    const results = await this._underlyingDb.query(
+    const results = await this._underlyingDb.query<TRecord>(
       onConflict
         ? sql`INSERT INTO ${this.tableId} (${columnNamesSql}) VALUES ${sql.join(
             values,
@@ -1237,12 +1237,12 @@ class Table<TRecord, TInsertParameters> {
     if (whereCondition === `FALSE`) {
       return 0;
     } else if (whereCondition === `TRUE`) {
-      const [result] = await this._underlyingDb.query(
+      const [result] = await this._underlyingDb.query<{count: string}>(
         sql`SELECT count(*) AS count FROM ${this.tableId}`,
       );
       return parseInt(result.count, 10);
     } else {
-      const [result] = await this._underlyingDb.query(
+      const [result] = await this._underlyingDb.query<{count: string}>(
         sql`SELECT count(*) AS count FROM ${this.tableId} WHERE ${whereCondition}`,
       );
       return parseInt(result.count, 10);

--- a/packages/pg/src/__tests__/index.test.pg.ts
+++ b/packages/pg/src/__tests__/index.test.pg.ts
@@ -100,14 +100,14 @@ test('error messages in a transaction', async function testErrorMessages() {
 });
 
 test('query', async () => {
-  const [{foo}] = await db.query(sql`SELECT 1 + 1 as foo`);
+  const [{foo}] = await db.query<{foo: number}>(sql`SELECT 1 + 1 as foo`);
   expect(foo).toBe(2);
 });
 
 test('query - multiple queries', async () => {
-  const resultA = await db.query([sql`SELECT 1 + 1 as foo`]);
+  const resultA = await db.query<[[{foo: number}]]>([sql`SELECT 1 + 1 as foo`]);
   expect(resultA).toEqual([[{foo: 2}]]);
-  const resultB = await db.query([
+  const resultB = await db.query<[[{foo: number}], [{bar: number}]]>([
     sql`SELECT ${1} + 1 as foo;`,
     sql`SELECT 1 + ${2} as bar;`,
   ]);
@@ -115,7 +115,9 @@ test('query - multiple queries', async () => {
 });
 
 test('query with params', async () => {
-  const [{foo}] = await db.query(sql`SELECT 1 + ${41} as ${sql.ident('foo')}`);
+  const [{foo}] = await db.query<{foo: number}>(
+    sql`SELECT 1 + ${41} as ${sql.ident('foo')}`,
+  );
   expect(foo).toBe(42);
 });
 
@@ -128,7 +130,7 @@ test('json', async () => {
     id: string,
     val: unknown,
   ): Promise<{id: string; val: unknown}> {
-    const [result] = await db.query(sql`
+    const [result] = await db.query<{id: string; val: unknown}>(sql`
       INSERT INTO json_test.json (id, val) VALUES (${id}, ${val})
       ON CONFLICT (id) DO UPDATE SET val=EXCLUDED.val
       RETURNING *;
@@ -139,7 +141,7 @@ test('json', async () => {
     id: string,
     val: unknown,
   ): Promise<{id: string; val: unknown}> {
-    const [result] = await db.query(sql`
+    const [result] = await db.query<{id: string; val: unknown}>(sql`
       INSERT INTO json_test.json (id, val) VALUES (${id}, ${JSON.stringify(
       val,
     )})
@@ -154,7 +156,7 @@ test('json', async () => {
       readonly val: unknown;
     }[]
   ): Promise<{id: string; val: unknown}[]> {
-    const results = await db.query(
+    const results = await db.query<{id: string; val: unknown}>(
       values.map(
         ({id, val}) => sql`
           INSERT INTO json_test.json (id, val)

--- a/packages/pg/src/__tests__/too-many-connections-for-role.test.pg.ts
+++ b/packages/pg/src/__tests__/too-many-connections-for-role.test.pg.ts
@@ -36,7 +36,9 @@ test(`Handling too many connections for role`, async () => {
       expect(
         await pool.tx(async (db) => {
           await new Promise<void>((r) => setTimeout(() => r(), 500));
-          return (await db.query(sql`SELECT 1+1 AS result`))[0].result;
+          return (
+            await db.query<{result: number}>(sql`SELECT 1+1 AS result`)
+          )[0].result;
         }),
       ).toBe(2);
     }),

--- a/packages/pg/src/__tests__/transaction-isolation.test.pg.ts
+++ b/packages/pg/src/__tests__/transaction-isolation.test.pg.ts
@@ -31,7 +31,7 @@ async function transaction(
   db: Transaction,
   {from, to, wait}: {from: number; to: number; wait: () => Promise<void>},
 ) {
-  const [{sum}] = await db.query(
+  const [{sum}] = await db.query<{sum: number}>(
     sql`SELECT SUM(value) as sum FROM mytab WHERE class = ${from};`,
   );
   await wait();

--- a/packages/pg/src/types/Queryable.ts
+++ b/packages/pg/src/types/Queryable.ts
@@ -7,8 +7,8 @@ import TransactionOptions from './TransactionOptions';
 export default interface Queryable {
   readonly type: QueryableType;
   readonly sql: SQL;
-  query(query: SQLQuery): Promise<any[]>;
-  query(query: SQLQuery[]): Promise<any[][]>;
+  query<T>(query: SQLQuery): Promise<T[]>;
+  query<T>(query: SQLQuery[]): Promise<T[][]>;
   queryStream(
     query: SQLQuery,
     {batchSize, signal}: {batchSize?: number; signal?: AbortSignal},


### PR DESCRIPTION
**Issue:**

This PR addresses issue #[302](https://github.com/ForbesLindesay/atdatabases/issues/302), which reported that the query method in the @databases/pg library lacks support for generic types, unlike the pool.query method from the pg library.

Please review the proposed changes and provide feedback. This PR aims to improve type safety and developer experience when using the @databases/pg library by allowing users to specify the expected result types when executing SQL queries.