### PR TITLE
feat: limit explicit defaults to static values

### DIFF
--- a/packages/pg-config/src/PgConfig.ts
+++ b/packages/pg-config/src/PgConfig.ts
@@ -327,10 +327,19 @@ export interface TypesConfig {
 
   /**
    * If true, the types will require a value to be provided,
-   * even if a column has a default value specified in the
-   * database schema. This can improve type safety due to the
-   * way that undefined is treated as equivalent to null at
-   * runtime.
+   * even if a column has a constant default value specified
+   * in the database schema. This can improve type safety due
+   * to the way that undefined is treated as equivalent to null
+   * at runtime.
+   *
+   * This will still allow you to omit columns on insert if they
+   * use `nextval('something')` to generate a unique key, or if
+   * they use `CURRENT_TIMESTAMP` to set a column to the current db
+   * time, or if they use any function call like `now()` or
+   * `uuid_generate_v4()`. Only constant defaults will still require
+   * an explicit value to be provided.
+   *
+   * @default false
    */
   requireExplicitDefaults: boolean;
 }

--- a/packages/pg-schema-print-types/src/printers/printClassDetails.ts
+++ b/packages/pg-schema-print-types/src/printers/printClassDetails.ts
@@ -166,10 +166,26 @@ function optionalOnInsert(
   context: PgPrintContext,
 ): string {
   if (!attribute.notNull) return '?';
-  if (attribute.hasDefault && !context.options.requireExplicitDefaults) {
+  if (
+    attribute.hasDefault &&
+    (!context.options.requireExplicitDefaults ||
+      isDynamicDefault(attribute.default.trim().toLowerCase()))
+  ) {
     return '?';
   }
   return '';
+}
+function isDynamicDefault(defaultValue: string): boolean {
+  let inString = false;
+  for (const character of defaultValue) {
+    if (character === '"' || character === "'") {
+      inString = !inString;
+    }
+    if (!inString && character === '(') {
+      return true;
+    }
+  }
+  return defaultValue === 'current_timestamp';
 }
 
 function handleBrand(


### PR DESCRIPTION
This should make it more useful by allowing you to still use it when using autogenerated ID columns.