### PR TITLE
Fix typo in queue.md documentation

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -6,7 +6,7 @@ sidebar_label: Queue
 
 The `@databases/queue` package provides a high speed queue, and a special "async" queue. Using a JavaScript Array as a Queue is very inefficient because each time you remove an item from the start of an Array, JavaScript must re-index every item in the array.
 
-Fortunately, JavaScript Array's are very efficient when used as stacks (i.e. you only use `push` and `pop`) because these operations do not require re-indexing. You can build an array out of two stacks, which is exaclty what `@databases/queue` does.
+Fortunately, JavaScript Array's are very efficient when used as stacks (i.e. you only use `push` and `pop`) because these operations do not require re-indexing. You can build an array out of two stacks, which is exactly what `@databases/queue` does.
 
 ## Usage
 


### PR DESCRIPTION
Corrected a typo in the documentation regarding the efficiency of JavaScript Arrays used as stacks.