### PR TITLE
chore(sqlite-sync): upgrade better-sqlite3 to v12

### DIFF
--- a/packages/sqlite-sync/package.json
+++ b/packages/sqlite-sync/package.json
@@ -8,8 +8,8 @@
     "@databases/escape-identifier": "^0.0.0",
     "@databases/sql": "^0.0.0",
     "@databases/split-sql-query": "^0.0.0",
-    "@types/better-sqlite3": "^7.6.9",
-    "better-sqlite3": "^11.3.0"
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.8.0"
   },
   "scripts": {},
   "repository": "https://github.com/ForbesLindesay/atdatabases/tree/master/packages/sqlite-sync",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,10 +1858,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/better-sqlite3@^7.6.9":
-  version "7.6.9"
-  resolved "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.9.tgz"
-  integrity sha512-FvktcujPDj9XKMJQWFcl2vVl7OdRIqsSRX9b0acWwTmwLK9CF2eqo/FRcmMLNpugKoX/avA6pb7TorDLmpgTnQ==
+"@types/better-sqlite3@^7.6.13":
+  version "7.6.13"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz#a72387f00d2f53cab699e63f2e2c05453cf953f0"
+  integrity sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==
   dependencies:
     "@types/node" "*"
 
@@ -2554,10 +2554,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-better-sqlite3@^11.3.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-11.3.0.tgz#f10b32ddff665c33176d148e707bd1e57dfd0284"
-  integrity sha512-iHt9j8NPYF3oKCNOO5ZI4JwThjt3Z6J6XrcwG85VNMVzv1ByqrHWv5VILEbCMFWDsoHhXvQ7oC8vgRXFAKgl9w==
+better-sqlite3@^12.8.0:
+  version "12.8.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.8.0.tgz#ec9ccd4a426a35f3b9355c147af6c92a6ddd6862"
+  integrity sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"


### PR DESCRIPTION
## Summary
- upgrade `better-sqlite3` in `@databases/sqlite-sync` from `^11.3.0` to `^12.8.0`
- refresh `@types/better-sqlite3` to `^7.6.13`
- update `yarn.lock`

## Testing
- `yarn install`
- `NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" TZ=Australia/Adelaide yarn jest packages/sqlite-sync/src/__tests__/index.test.ts packages/sqlite-sync/src/__tests__/stream.test.ts --runInBand`
